### PR TITLE
iOS Notification Support

### DIFF
--- a/birthday_calendar/ios/Runner/AppDelegate.swift
+++ b/birthday_calendar/ios/Runner/AppDelegate.swift
@@ -9,5 +9,10 @@ import Flutter
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    }
+
   }
 }

--- a/birthday_calendar/lib/main.dart
+++ b/birthday_calendar/lib/main.dart
@@ -9,7 +9,6 @@ import 'package:birthday_calendar/service/shared_prefs.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await SharedPrefs().init();
-  await NotificationService().init();
   runApp(MyApp());
 }
 
@@ -67,11 +66,37 @@ class _MyHomePageState extends State<MyHomePage> {
     _calculateNextMonthToShow(AxisDirection.left);
   }
 
+  void _onDidReceiveLocalNotification(
+      int id,
+      String title,
+      String body,
+      String payload) async {
+          showDialog(
+              context: context,
+              builder: (BuildContext context) =>
+                  AlertDialog(
+                      title: Text(title),
+                      content: Text(body),
+                      actions: [
+                        TextButton(
+                          child: Text("Ok"),
+                           onPressed: () async {
+                              main();
+                            }
+                          )
+                      ]
+                  )
+          );
+  }
+
+
   @override
   void initState() {
     monthToPresent = widget.currentMonth;
     month = DateService().convertMonthToWord(monthToPresent);
-    NotificationService().handleApplicationWasLaunchedFromNotification();
+    NotificationService().init(_onDidReceiveLocalNotification).whenComplete(() =>
+        NotificationService().handleApplicationWasLaunchedFromNotification()
+    );
     super.initState();
   }
 

--- a/birthday_calendar/lib/main.dart
+++ b/birthday_calendar/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:birthday_calendar/service/date_service.dart';
 import 'package:birthday_calendar/service/notification_service.dart';
 import 'package:birthday_calendar/service/shared_prefs.dart';
 
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await SharedPrefs().init();
@@ -75,13 +76,13 @@ class _MyHomePageState extends State<MyHomePage> {
               context: context,
               builder: (BuildContext context) =>
                   AlertDialog(
-                      title: Text(title),
-                      content: Text(body),
+                      title: Text(title ?? ''),
+                      content: Text(body ?? ''),
                       actions: [
                         TextButton(
                           child: Text("Ok"),
                            onPressed: () async {
-                              main();
+                             NotificationService().handleApplicationWasLaunchedFromNotification(payload ?? '');
                             }
                           )
                       ]
@@ -95,7 +96,7 @@ class _MyHomePageState extends State<MyHomePage> {
     monthToPresent = widget.currentMonth;
     month = DateService().convertMonthToWord(monthToPresent);
     NotificationService().init(_onDidReceiveLocalNotification).whenComplete(() =>
-        NotificationService().handleApplicationWasLaunchedFromNotification()
+        NotificationService().handleApplicationWasLaunchedFromNotification("")
     );
     super.initState();
   }

--- a/birthday_calendar/lib/service/notification_service.dart
+++ b/birthday_calendar/lib/service/notification_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' show Platform;
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/data/latest.dart' as tz;
@@ -109,14 +110,18 @@ class NotificationService {
     await flutterLocalNotificationsPlugin.cancelAll();
   }
 
-  void handleApplicationWasLaunchedFromNotification() async {
+  void handleApplicationWasLaunchedFromNotification(String payload) async {
+
+    if (Platform.isIOS) {
+      _rescheduleNotificationFromPayload(payload);
+      return;
+    }
+
     final NotificationAppLaunchDetails notificationAppLaunchDetails =
         await flutterLocalNotificationsPlugin.getNotificationAppLaunchDetails();
 
     if (notificationAppLaunchDetails.didNotificationLaunchApp) {
-      UserBirthday userBirthday = getUserBirthdayFromPayload(notificationAppLaunchDetails.payload);
-      cancelNotificationForBirthday(userBirthday);
-      scheduleNotificationForBirthday(userBirthday, "${userBirthday.name} has an upcoming birthday!");
+      _rescheduleNotificationFromPayload(notificationAppLaunchDetails.payload);
     }
   }
 
@@ -131,5 +136,11 @@ class NotificationService {
     await flutterLocalNotificationsPlugin.getNotificationAppLaunchDetails();
 
     return notificationAppLaunchDetails.didNotificationLaunchApp;
+  }
+
+  void _rescheduleNotificationFromPayload(String payload) {
+    UserBirthday userBirthday = getUserBirthdayFromPayload(payload);
+    cancelNotificationForBirthday(userBirthday);
+    scheduleNotificationForBirthday(userBirthday, "${userBirthday.name} has an upcoming birthday!");
   }
 }

--- a/birthday_calendar/lib/service/notification_service.dart
+++ b/birthday_calendar/lib/service/notification_service.dart
@@ -22,14 +22,17 @@ class NotificationService {
 
   static const channel_id = "123";
 
-  Future<void> init() async {
+  Future<void> init(Function onDidReceive) async {
 
     final AndroidInitializationSettings initializationSettingsAndroid =
     AndroidInitializationSettings('app_icon');
 
+    final IOSInitializationSettings initializationSettingsIOS =
+    IOSInitializationSettings(onDidReceiveLocalNotification: onDidReceive);
+
     final InitializationSettings initializationSettings =
         InitializationSettings(
-            android: initializationSettingsAndroid, iOS: null, macOS: null);
+            android: initializationSettingsAndroid, iOS: initializationSettingsIOS, macOS: null);
     await flutterLocalNotificationsPlugin.initialize(initializationSettings,
         onSelectNotification: selectNotification);
     tz.initializeTimeZones();


### PR DESCRIPTION
Fixes #4 

In order to allow the application to be able to handle notification on iOS devices, it was needed to add the relevant logic described in the local notifications package.

Furthermore, this required some refactoring in:
- Main: had to change init method to receive callback needed by iOS
- NotificationService - some refactoring to minimize duplicated code
- Changes following move to null safety