### PR TITLE
Bugfix: User notification

### DIFF
--- a/lib/service/StorageServiceSharedPreferences.dart
+++ b/lib/service/StorageServiceSharedPreferences.dart
@@ -62,6 +62,8 @@ class StorageServiceSharedPreferences extends StorageService {
         savedBirthday.updateNotificationStatus(updatedStatus);
       }
     }
+
+    saveBirthdaysForDate(userBirthday.birthdayDate, birthdays);
   }
 
 }

--- a/lib/widget/add_birthday_form.dart
+++ b/lib/widget/add_birthday_form.dart
@@ -104,7 +104,7 @@ class AddBirthdayFormState extends State<AddBirthdayForm> {
 
               UserBirthday userBirthday = new UserBirthday(_birthdayPersonController.text,
                   widget.dateOfDay,
-                  false,
+                  true,
                   _phoneNumber.parseNumber());
               Navigator.pop(context, userBirthday);
             } else {

--- a/lib/widget/birthday.dart
+++ b/lib/widget/birthday.dart
@@ -82,7 +82,7 @@ class _BirthdayWidgetState extends State<BirthdayWidget> {
           new Spacer(),
           new IconButton(
               icon: Icon(
-                  isNotificationEnabledForPerson
+                  !isNotificationEnabledForPerson
                       ? Icons.notifications_off_outlined
                       : Icons.notifications_active_outlined,
                   color:  _getColorBasedOnPosition(widget.indexOfBirthday, "icon")),


### PR DESCRIPTION
Fixes #31 

After looking at the code, these things were noticed:

- The ternary for deciding which notification icon to present had a missing exclamation mark (!)
- Logic to save the updated notification state per user was missing in shared preferences
- The flag for the notification status when creating a birthday was set to false even though we were setting a notification for that user
