### PR TITLE
Fix: Chevon Icon Color

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -167,7 +167,7 @@ class _MyHomePageState extends State<MyHomePage> {
                         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                         children: [
                           new IconButton(icon:
-                          new Icon(Icons.chevron_left, color: Colors.black),
+                          new Icon(Icons.chevron_left),
                               onPressed: () {
                                 _calculateNextMonthToShow(AxisDirection.right);
                               }),
@@ -177,7 +177,7 @@ class _MyHomePageState extends State<MyHomePage> {
                               currentMonth:monthToPresent),
                           ),
                           new IconButton(icon:
-                          new Icon(Icons.chevron_right, color: Colors.black),
+                          new Icon(Icons.chevron_right),
                               onPressed: () {
                                 _calculateNextMonthToShow(AxisDirection.left);
                               }),


### PR DESCRIPTION
Fixes #36 
Removed colors from chevron icons so that they will receive the default theme color