### PR TITLE
Fix: Clearing birthdays from storage

### DIFF
--- a/lib/page/settings_page/settings_screen_manager.dart
+++ b/lib/page/settings_page/settings_screen_manager.dart
@@ -47,7 +47,7 @@ class SettingsScreenManager extends ChangeNotifier {
   }
 
   void onClearBirthdaysPressed() async {
-    await _storageService.clearAllBirthdays();
+    _storageService.clearAllBirthdays();
     _didClearNotifications = true;
   }
 

--- a/lib/service/storage_service/shared_preferences_storage.dart
+++ b/lib/service/storage_service/shared_preferences_storage.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:async';
 import 'package:birthday_calendar/constants.dart';
 import 'package:birthday_calendar/model/user_birthday.dart';
+import 'package:intl/intl.dart';
 import 'storage_service.dart';
 import '../date_service/date_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -13,9 +14,18 @@ class StorageServiceSharedPreferences extends StorageService {
   StreamController<List<UserBirthday>> streamController = StreamController<List<UserBirthday>>.broadcast();
 
   @override
-  Future<bool> clearAllBirthdays() async {
+  void clearAllBirthdays() async {
     final sharedPreferences = await SharedPreferences.getInstance();
-    return sharedPreferences.clear();
+    Set<String> keys = sharedPreferences.getKeys();
+    DateFormat format = DateFormat('yyyy-MM-dd');
+    for (String key in keys) {
+        try {
+          format.parse(key);
+          sharedPreferences.remove(key);
+        } catch (error) {
+
+        }
+    }
   }
 
   @override

--- a/lib/service/storage_service/storage_service.dart
+++ b/lib/service/storage_service/storage_service.dart
@@ -4,7 +4,7 @@ import 'package:birthday_calendar/model/user_birthday.dart';
 abstract class StorageService {
   Future<List<UserBirthday>> getBirthdaysForDate(DateTime dateTime, bool shouldGetBirthdaysFromSimilarDate);
   Future<void> saveBirthdaysForDate(DateTime dateTime, List<UserBirthday> birthdays);
-  Future<bool> clearAllBirthdays();
+  void clearAllBirthdays();
   Future<void> updateNotificationStatusForBirthday(UserBirthday userBirthday, bool updatedStatus);
 
   Future<bool> getThemeModeSetting();


### PR DESCRIPTION
Due to recent changes in saving data to shared preferences, it was needed to alter the logic in **_clearAllBirthdays_** method to only remove birthdays.