### PR TITLE
Upgrading com.google.android.play:core to a version that is compatible with API 34

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -220,10 +220,10 @@ packages:
     dependency: "direct main"
     description:
       name: in_app_update
-      sha256: cc7e96b4f09b6f968598b804157c279e34d3ab661d1e3bea333751826496eb5f
+      sha256: "489572accaa55b51518b2d64676ca8c3c6d4c989fa53cf718001882237691a3c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "4.2.3"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   permission_handler: ^10.2.0
   flutter_contacts: ^1.1.7+1
   provider: ^6.0.2
-  in_app_update: ^3.0.0
+  in_app_update: ^4.1.0
   flutter_bloc: ^8.1.5
 
 dev_dependencies:


### PR DESCRIPTION
Resolves #75 

Due to the fact that the in-app-update relies on com.google.android.play:core as a dependency, it was necessary to upgrade it from the current version (3.0.0).

Per the release notes of in-app-update, version 4.1.0 includes the migration from com.google.android.play:core.