### PR TITLE
Fix: Accessing phone numbers when importing contacts

### DIFF
--- a/lib/service/contacts_service/contacts_service_impl.dart
+++ b/lib/service/contacts_service/contacts_service_impl.dart
@@ -89,7 +89,7 @@ class ContactsServiceImpl extends ContactsService {
 
   @override
   Future<List<Contact>> fetchContacts(bool withThumbnails) async {
-    return await FlutterContacts.getContacts();
+    return await FlutterContacts.getContacts(withProperties: true);
   }
 
   void addContactToCalendar(UserBirthday contact) async {


### PR DESCRIPTION
Fixes #74 

It turns out that it was needed to add the argument **withProperties:true** when importing contacts.

`FlutterContacts.getContacts(withProperties: true)`