### PR TITLE
Crash: androidx.window.layout.ExtensionWindowLayoutInfoBackend.registerLayoutChangeCallback

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,4 +76,6 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+    implementation 'androidx.window:window:1.0.0'
+    implementation 'androidx.window:window-java:1.0.0'
 }


### PR DESCRIPTION
Fixes #85 

As proposed in flutter_local_notifications documentation, added the necessary libraries.