### PR TITLE
BirthdayCalendar creating publish action for android

### DIFF
--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: 'zulu'
+          java-version: '12.x'
 
       - name: Build Release AAB
         run: flutter build appbundle --release

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{secrets.SERVICE_ACCOUNT}}
           packageName: com.tomerpacific.birthday_calendar
-          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          releaseFiles: build/app/outputs/bundle/release/*.aab
           track: production
           status: completed
 

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Sign AAB
         uses: r0adkll/sign-android-release@v1
         with:
-            releaseDirectory: app/build/outputs/bundle/release
+            releaseDirectory: build/app/outputs/bundle/release/*.aab
             signingKeyBase64: ${{ secrets.SIGN_KEY }}
             alias: ${{ secrets.ALIAS }}
             keyStorePassword: ${{ secrets.STORE_KEY_PASSWORD }}

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -16,17 +16,20 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '12.x'
+
       - name: Set Up Flutter
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.27.0'
           cache: true
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '12.x'
+      - name: Get Flutter dependencies
+        run: flutter pub get
 
       - name: Build Release AAB
         run: flutter build appbundle --release

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -1,0 +1,41 @@
+name: Android Publish
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Android Build]
+    types: [completed]
+    branches: ['release/**']
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set Up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.27.0'
+          cache: true
+
+      - name: Build Release AAB
+        run: flutter build appbundle
+
+      - name: Deploy to Play Store
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{secrets.SERVICE_ACCOUNT}}
+          packageName: com.tomerpacific.birthday_calendar
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          track: production
+          status: completed
+
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'Publish workflow failed due to Build workflow failing'

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -3,7 +3,7 @@ name: Android Publish
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [flutter build]
+    workflows: [Flutter build]
     types: [completed]
     branches: ['release/**']
 

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -3,7 +3,7 @@ name: Android Publish
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [Android Build]
+    workflows: [flutter build]
     types: [completed]
     branches: ['release/**']
 
@@ -22,8 +22,23 @@ jobs:
           flutter-version: '3.27.0'
           cache: true
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Build Release AAB
-        run: flutter build appbundle
+        run: flutter build appbundle --release
+
+      - name: Sign AAB
+        uses: r0adkll/sign-android-release@v1
+        with:
+            releaseDirectory: app/build/outputs/bundle/release
+            signingKeyBase64: ${{ secrets.SIGN_KEY }}
+            alias: ${{ secrets.ALIAS }}
+            keyStorePassword: ${{ secrets.STORE_KEY_PASSWORD }}
+            keyPassword: ${{ secrets.KEY_PASSWORD }}
 
       - name: Deploy to Play Store
         uses: r0adkll/upload-google-play@v1

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -26,6 +26,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.27.0'
+          channel: stable
           cache: true
 
       - name: Get Flutter dependencies

--- a/.github/workflows/flutter_build.yml
+++ b/.github/workflows/flutter_build.yml
@@ -4,7 +4,6 @@ on: pull_request
 
 jobs:
   build:
-    name: flutter build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Resolves #116 

This pull request introduces a new GitHub Actions workflow for automating the publishing of the Android app to the Play Store. The workflow is triggered after a successful build on release branches and handles both successful and failed build scenarios.

**New Android publishing workflow:**

* Added `.github/workflows/android_publish.yml` to automate publishing Android releases to the Play Store after a successful build on `release/**` branches.
* The workflow sets up Flutter, builds the release app bundle (`.aab`), and deploys it to the Play Store using service account credentials.
* Includes a failure job to notify when the build workflow fails, improving visibility of publishing issues.