### PR TITLE
Deleting a birthday does not cancel its scheduled notification

### DIFF
--- a/lib/BirthdayBloc/BirthdaysBloc.dart
+++ b/lib/BirthdayBloc/BirthdaysBloc.dart
@@ -90,7 +90,7 @@ class BirthdaysBloc extends Bloc<BirthdaysEvent, BirthdaysState> {
         await storageService.getBirthdaysForDate(birthdayDate, false);
 
     List<UserBirthday> filteredBirthdays = birthdaysForDateDeleted
-        .where((element) => !element.equals(userBirthday))
+        .where((element) => element != userBirthday)
         .toList();
 
     await storageService.saveBirthdaysForDate(birthdayDate, filteredBirthdays);

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -17,6 +17,7 @@ const userBirthdayNameKey = "name";
 const userBirthdayDateKey = "birthdayDate";
 const userBirthdayHasNotificationKey = "hasNotification";
 const userBirthdayPhoneNumberKey = "phoneNumber";
+const userBirthdayNotificationIdKey = "notificationId";
 
 const darkModeKey = "darkMode";
 const contactsPermissionKey = "contacts";

--- a/lib/model/user_birthday.dart
+++ b/lib/model/user_birthday.dart
@@ -5,9 +5,13 @@ class UserBirthday {
   final DateTime birthdayDate;
   bool hasNotification;
   String phoneNumber;
+  final int notificationId;
 
   UserBirthday(
-      this.name, this.birthdayDate, this.hasNotification, this.phoneNumber);
+      this.name, this.birthdayDate, this.hasNotification, this.phoneNumber,
+      {int? notificationId})
+      : this.notificationId = notificationId ??
+            (name.hashCode ^ birthdayDate.hashCode).toUnsigned(31);
 
   void updateNotificationStatus(bool status) {
     this.hasNotification = status;
@@ -34,12 +38,19 @@ class UserBirthday {
         birthdayDate =
             DateTime.tryParse(json[userBirthdayDateKey]) ?? DateTime.now(),
         hasNotification = json[userBirthdayHasNotificationKey],
-        phoneNumber = json[userBirthdayPhoneNumberKey];
+        phoneNumber = json[userBirthdayPhoneNumberKey],
+        notificationId = json[userBirthdayNotificationIdKey] ??
+            (json[userBirthdayNameKey].hashCode ^
+                    (DateTime.tryParse(json[userBirthdayDateKey]) ??
+                            DateTime.now())
+                        .hashCode)
+                .toUnsigned(31);
 
   Map<String, dynamic> toJson() => {
         userBirthdayNameKey: name,
         userBirthdayDateKey: birthdayDate.toIso8601String(),
         userBirthdayHasNotificationKey: hasNotification,
-        userBirthdayPhoneNumberKey: phoneNumber
+        userBirthdayPhoneNumberKey: phoneNumber,
+        userBirthdayNotificationIdKey: notificationId
       };
 }

--- a/lib/model/user_birthday.dart
+++ b/lib/model/user_birthday.dart
@@ -13,6 +13,17 @@ class UserBirthday {
     this.hasNotification = status;
   }
 
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserBirthday &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          birthdayDate == other.birthdayDate;
+
+  @override
+  int get hashCode => name.hashCode ^ birthdayDate.hashCode;
+
   bool equals(UserBirthday otherBirthday) {
     return (this.name == otherBirthday.name &&
         this.birthdayDate == otherBirthday.birthdayDate);

--- a/lib/service/notification_service/notification_service_impl.dart
+++ b/lib/service/notification_service/notification_service_impl.dart
@@ -140,7 +140,7 @@ class NotificationServiceImpl extends NotificationService {
   Future<void> _showNotification(
       UserBirthday userBirthday, String notificationMessage) async {
     await flutterLocalNotificationsPlugin.show(
-        userBirthday.hashCode,
+        userBirthday.notificationId,
         applicationName,
         notificationMessage,
         NotificationDetails(android: _createAndroidNotificationDetails()),
@@ -174,7 +174,7 @@ class NotificationServiceImpl extends NotificationService {
     }
 
     await flutterLocalNotificationsPlugin.zonedSchedule(
-        userBirthday.hashCode,
+        userBirthday.notificationId,
         applicationName,
         notificationMessage,
         tz.TZDateTime.now(tz.local).add(difference),
@@ -186,7 +186,7 @@ class NotificationServiceImpl extends NotificationService {
   Future<void> _scheduleNotificationForNextYear(
       UserBirthday userBirthday, String notificationMessage) async {
     await flutterLocalNotificationsPlugin.zonedSchedule(
-        userBirthday.hashCode,
+        userBirthday.notificationId,
         applicationName,
         notificationMessage,
         tz.TZDateTime.now(tz.local).add(new Duration(days: 365)),
@@ -196,7 +196,7 @@ class NotificationServiceImpl extends NotificationService {
   }
 
   Future<void> cancelNotificationForBirthday(UserBirthday birthday) async {
-    await flutterLocalNotificationsPlugin.cancel(birthday.hashCode);
+    await flutterLocalNotificationsPlugin.cancel(birthday.notificationId);
   }
 
   Future<void> cancelAllNotifications() async {


### PR DESCRIPTION
Resolves #124 

This pull request introduces a more robust and explicit way to handle notification IDs for user birthdays, replacing the previous reliance on `hashCode` with a dedicated `notificationId` property in the `UserBirthday` model. Additionally, it improves equality checks for `UserBirthday` objects and ensures that notification scheduling and cancellation use the new identifier. 

**UserBirthday Model Enhancements:**

* Added a new `notificationId` property to `UserBirthday`, generated from the user's name and birthday date, and included it in serialization/deserialization logic (`user_birthday.dart`, `constants.dart`). [[1]](diffhunk://#diff-ffc9dd2fb7ad6b6c611ec7eb13703dfa34a6cb0e211fd4177cdba91145f2d1f9R8-R30) [[2]](diffhunk://#diff-ffc9dd2fb7ad6b6c611ec7eb13703dfa34a6cb0e211fd4177cdba91145f2d1f9L26-R54) [[3]](diffhunk://#diff-e32d5555dcbfb615fa5808711c8d437da76ed26893cdf3c2c2004ff5817c529fR20)
* Implemented custom `==` operator and `hashCode` for `UserBirthday` to ensure equality is based on name and birthday date, improving reliability in comparisons and collections.

**Notification Handling Updates:**

* Updated all notification-related methods in `NotificationServiceImpl` to use `userBirthday.notificationId` instead of `userBirthday.hashCode` for scheduling, showing, and canceling notifications. [[1]](diffhunk://#diff-d41232a2c0a35347aa5fde8b5ce0b502d01288f9c10f48c3fe101626dcd8ca67L143-R143) [[2]](diffhunk://#diff-d41232a2c0a35347aa5fde8b5ce0b502d01288f9c10f48c3fe101626dcd8ca67L177-R177) [[3]](diffhunk://#diff-d41232a2c0a35347aa5fde8b5ce0b502d01288f9c10f48c3fe101626dcd8ca67L189-R189) [[4]](diffhunk://#diff-d41232a2c0a35347aa5fde8b5ce0b502d01288f9c10f48c3fe101626dcd8ca67L199-R199)

**Code Consistency:**

* Modified logic in `BirthdaysBloc` to use the new equality operator (`!=`) for filtering, aligning with the improved equality definition in `UserBirthday`.