### PR TITLE
"Clear Notifications" clears birthday storage but does not cancel system notifications

### DIFF
--- a/lib/ClearNotificationsBloc/ClearNotificationsBloc.dart
+++ b/lib/ClearNotificationsBloc/ClearNotificationsBloc.dart
@@ -5,8 +5,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 enum ClearNotificationsEvent { ClearedNotifications }
 
 class ClearNotificationsBloc extends Bloc<ClearNotificationsEvent, bool> {
-  ClearNotificationsBloc(
-      StorageService storageService, NotificationService notificationService)
+
+  final StorageService storageService;
+  final NotificationService notificationService;
+
+  ClearNotificationsBloc(this.storageService, this.notificationService)
       : super(false) {
     on<ClearNotificationsEvent>((event, emit) async {
       if (event == ClearNotificationsEvent.ClearedNotifications) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:birthday_calendar/ClearNotificationsBloc/ClearNotificationsBloc.dart';
 import 'package:birthday_calendar/ContactsPermissionStatusBloc/ContactsPermissionStatusBloc.dart';
 import 'package:birthday_calendar/BirthdayCalendarDateUtils.dart';
 import 'package:birthday_calendar/ThemeBloc/ThemeBloc.dart';
@@ -62,6 +63,10 @@ class MyApp extends StatelessWidget {
             BlocProvider(
                 create: (context) =>
                     ContactsPermissionStatusBloc(contactsService)),
+            BlocProvider(
+                create: (context) => ClearNotificationsBloc(
+                    context.read<StorageServiceSharedPreferences>(),
+                    notificationService)),
             BlocProvider(create: (context) => VersionBloc())
           ],
           child: BlocBuilder<ThemeBloc, ThemeMode>(

--- a/lib/page/main_page/main_page.dart
+++ b/lib/page/main_page/main_page.dart
@@ -150,13 +150,9 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-        create: (context) => ClearNotificationsBloc(
-            context.read<StorageServiceSharedPreferences>(),
-            widget.notificationService),
-        child: BlocBuilder<ClearNotificationsBloc, bool>(
-            builder: (context, state) {
-          return Scaffold(
+    return BlocBuilder<ClearNotificationsBloc, bool>(
+        builder: (context, state) {
+      return Scaffold(
               appBar: AppBar(
                 actions: [
                   IconButton(
@@ -164,12 +160,10 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
                       Icons.settings,
                     ),
                     onPressed: () {
-                      unawaited(Navigator.push(context, MaterialPageRoute(builder: (_) {
-                        return BlocProvider.value(
-                            value: BlocProvider.of<ClearNotificationsBloc>(
-                                context),
-                            child: SettingsScreen(
-                                contactsService: widget.contactsService));
+                      unawaited(Navigator.push(context,
+                          MaterialPageRoute(builder: (context) {
+                        return SettingsScreen(
+                            contactsService: widget.contactsService);
                       })).then((result) {}));
                     },
                   )
@@ -230,7 +224,7 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
                       ],
                     )),
               ));
-        }));
+    });
   }
 
   @override


### PR DESCRIPTION
Resolves #125 

This pull request refactors how the `ClearNotificationsBloc` is provided throughout the app, ensuring it is created at a higher level in the widget tree and removing redundant BlocProviders from individual screens. This change centralizes the bloc's lifecycle, making state management more predictable and efficient.

**Bloc Provisioning Refactor:**

* The `ClearNotificationsBloc` is now provided at the top-level in `main.dart` using a single `BlocProvider`, rather than being created in individual screens like `MainPage`. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R1) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R66-R69)
* The redundant `BlocProvider` for `ClearNotificationsBloc` in `MainPage` was removed, and widgets now access the existing bloc from the context. [[1]](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL153-R153) [[2]](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL233-R227)

**Bloc Constructor Refactor:**

* The `ClearNotificationsBloc` constructor was updated to use named instance variables, improving code clarity and maintainability.

**Navigation Simplification:**

* Navigation to the `SettingsScreen` no longer wraps the screen in a new `BlocProvider.value` for `ClearNotificationsBloc`, since the bloc is now available higher up in the widget tree.