### PR TITLE
Birthdays that have already passed this year are scheduled with a wrong notification date

### DIFF
--- a/lib/service/notification_service/notification_service_impl.dart
+++ b/lib/service/notification_service/notification_service_impl.dart
@@ -172,13 +172,14 @@ class NotificationServiceImpl extends NotificationService {
     }
   }
 
-  /// Returns a TZDateTime for the birthday's month/day in [year].
+  /// Returns a TZDateTime for the birthday's month/day in [year] at 09:00 AM.
   tz.TZDateTime _birthdayInYear(UserBirthday userBirthday, int year) {
     return tz.TZDateTime(
       tz.local,
       year,
       userBirthday.birthdayDate.month,
       userBirthday.birthdayDate.day,
+      9,
     );
   }
 
@@ -187,22 +188,17 @@ class NotificationServiceImpl extends NotificationService {
     final tz.TZDateTime now = tz.TZDateTime.now(tz.local);
     tz.TZDateTime nextOccurrence = _birthdayInYear(userBirthday, now.year);
 
-    // If today is the birthday, handle immediately; otherwise if this year's
-    // date has already passed, advance to next year.
-    final bool isToday = nextOccurrence.year == now.year &&
-        nextOccurrence.month == now.month &&
-        nextOccurrence.day == now.day;
-
-    if (isToday) {
-      bool didApplicationLaunchFromNotification =
-          await _wasApplicationLaunchedFromNotification();
-      if (!didApplicationLaunchFromNotification) {
-        // Show the notification immediately for today's birthday, then fall
-        // through to schedule next year's occurrence below.
-        await _showNotification(userBirthday, notificationMessage);
+    if (nextOccurrence.isBefore(now)) {
+      // If it's today and we already passed the scheduled time, show it now.
+      if (nextOccurrence.year == now.year &&
+          nextOccurrence.month == now.month &&
+          nextOccurrence.day == now.day) {
+        bool didApplicationLaunchFromNotification =
+            await _wasApplicationLaunchedFromNotification();
+        if (!didApplicationLaunchFromNotification) {
+          await _showNotification(userBirthday, notificationMessage);
+        }
       }
-      nextOccurrence = _birthdayInYear(userBirthday, now.year + 1);
-    } else if (now.isAfter(nextOccurrence)) {
       nextOccurrence = _birthdayInYear(userBirthday, now.year + 1);
     }
 


### PR DESCRIPTION
Fixes #128 

This pull request updates the birthday notification scheduling logic to ensure notifications are triggered at 9:00 AM on the user's birthday and improves how the service handles birthdays that occur on the current day but after the scheduled time. The changes make the notification timing more precise and the scheduling logic clearer.

**Notification timing improvements:**

* The `_birthdayInYear` method now schedules birthday notifications specifically at 9:00 AM on the user's birthday, instead of the default time (midnight).

**Scheduling logic improvements:**

* The logic for handling birthdays that are today but have already passed the scheduled notification time has been updated. Now, if the current time is after 9:00 AM on the birthday, the notification is shown immediately (unless the app was launched from the notification), and the next occurrence is scheduled for the following year.