### PR TITLE
All CalendarDayWidgets in a month share the same Key

### DIFF
--- a/lib/widget/calendar.dart
+++ b/lib/widget/calendar.dart
@@ -41,7 +41,7 @@ class _CalendarState extends State<CalendarWidget> {
               shrinkWrap: true,
               itemBuilder: (BuildContext context, int index) {
                 return new CalendarDayWidget(
-                    key: Key(widget.currentMonth.toString()),
+                    key: Key("${widget.currentMonth}-${index + 1}"),
                     date: BirthdayCalendarDateUtils
                         .constructDateTimeFromDayAndMonth(
                             (index + 1), widget.currentMonth),


### PR DESCRIPTION
Fixes #135 

This pull request makes a minor update to the key generation for `CalendarDayWidget` in the `calendar.dart` file. The change ensures that each day widget has a unique key based on both the current month and the day index, which helps Flutter efficiently manage widget states during rebuilds.

- Improved widget key uniqueness by including both `currentMonth` and day index in the `CalendarDayWidget` key.