### PR TITLE
AddBirthdayForm clears the name field when the phone number is invalid

### DIFF
--- a/lib/widget/add_birthday_form.dart
+++ b/lib/widget/add_birthday_form.dart
@@ -180,7 +180,7 @@ class AddBirthdayFormState extends State<AddBirthdayForm> {
                 }
                 if (_phoneNumberKey.currentState != null &&
                     !_phoneNumberKey.currentState!.isValid) {
-                  _birthdayPersonController.clear();
+                  _phoneNumberController.clear();
                 }
               }
             },


### PR DESCRIPTION
Fixes #137 

This pull request makes a minor fix to the `AddBirthdayForm` widget. The change ensures that when the phone number field is invalid, the `_phoneNumberController` is cleared instead of the unrelated `_birthdayPersonController`.

- Fixed logic in `AddBirthdayFormState` to clear `_phoneNumberController` when the phone number field is invalid, preventing accidental clearing of the birthday person's name.