### PR TITLE
StorageService is instantiated twice — services and widgets use different instances

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ Future<void> main() async {
   bool isDarkMode = await storageService.getThemeModeSetting();
 
   runApp(MyApp(
+    storageService: storageService,
     notificationService: notificationService,
     contactsService: contactsService,
     isDarkMode: isDarkMode,
@@ -42,30 +43,32 @@ Future<void> main() async {
 
 class MyApp extends StatelessWidget {
   MyApp(
-      {required this.notificationService,
+      {required this.storageService,
+      required this.notificationService,
       required this.contactsService,
       required this.isDarkMode});
 
+  final StorageService storageService;
   final NotificationService notificationService;
   final ContactsService contactsService;
   final bool isDarkMode;
 
   @override
   Widget build(BuildContext context) {
-    return RepositoryProvider(
-        create: (context) => StorageServiceSharedPreferences(),
+    return RepositoryProvider.value(
+        value: storageService,
         child: MultiBlocProvider(
           providers: [
             BlocProvider(
                 create: (context) => ThemeBloc(
-                    context.read<StorageServiceSharedPreferences>(),
+                    context.read<StorageService>(),
                     isDarkMode)),
             BlocProvider(
                 create: (context) =>
                     ContactsPermissionStatusBloc(contactsService)),
             BlocProvider(
                 create: (context) => ClearNotificationsBloc(
-                    context.read<StorageServiceSharedPreferences>(),
+                    context.read<StorageService>(),
                     notificationService)),
             BlocProvider(create: (context) => VersionBloc())
           ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,7 @@ Future<void> main() async {
 
   bool isDarkMode = await storageService.getThemeModeSetting();
 
-  runApp(MyApp(
+  runApp(BirthdayCalendarApp(
     storageService: storageService,
     notificationService: notificationService,
     contactsService: contactsService,
@@ -41,8 +41,8 @@ Future<void> main() async {
   ));
 }
 
-class MyApp extends StatelessWidget {
-  MyApp(
+class BirthdayCalendarApp extends StatelessWidget {
+  BirthdayCalendarApp(
       {required this.storageService,
       required this.notificationService,
       required this.contactsService,

--- a/lib/page/birthday/birthday.dart
+++ b/lib/page/birthday/birthday.dart
@@ -3,7 +3,7 @@ import 'package:birthday_calendar/BirthdayBloc/BirthdaysBloc.dart';
 import 'package:birthday_calendar/UserNotificationStatusBloc/UserNotificationStatusBloc.dart';
 import 'package:birthday_calendar/l10n/app_localizations.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
-import 'package:birthday_calendar/service/storage_service/shared_preferences_storage.dart';
+import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:birthday_calendar/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:birthday_calendar/model/user_birthday.dart';
@@ -85,7 +85,7 @@ class _BirthdayWidgetState extends State<BirthdayWidget> {
                 String phone = _birthdayPhoneNumber.parseNumber();
                 birthdayOfPerson.phoneNumber = phone;
                 await context
-                    .read<StorageServiceSharedPreferences>()
+                    .read<StorageService>()
                     .updatePhoneNumberForBirthday(birthdayOfPerson);
                 if (!mounted || !context.mounted) return;
                 setState(() {});
@@ -153,7 +153,7 @@ class _BirthdayWidgetState extends State<BirthdayWidget> {
           new Spacer(),
           BlocProvider(
               create: (context) => UserNotificationStatusBloc(
-                  context.read<StorageServiceSharedPreferences>(),
+                  context.read<StorageService>(),
                   notificationService),
               child: BlocBuilder<UserNotificationStatusBloc, bool>(
                   builder: (context, state) {

--- a/lib/page/birthdays_for_calendar_day_page/birthdays_for_calendar_day.dart
+++ b/lib/page/birthdays_for_calendar_day_page/birthdays_for_calendar_day.dart
@@ -3,7 +3,7 @@ import 'package:birthday_calendar/BirthdayBloc/BirthdaysState.dart';
 import 'package:birthday_calendar/BirthdayCalendarDateUtils.dart';
 import 'package:birthday_calendar/l10n/app_localizations.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
-import 'package:birthday_calendar/service/storage_service/shared_preferences_storage.dart';
+import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:birthday_calendar/widget/add_birthday_form.dart';
 import 'package:flutter/material.dart';
 import 'package:birthday_calendar/page/birthday/birthday.dart';
@@ -26,7 +26,7 @@ class BirthdaysForCalendarDayWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocProvider(
         create: (context) => BirthdaysBloc(notificationService,
-            context.read<StorageServiceSharedPreferences>(), birthdays),
+            context.read<StorageService>(), birthdays),
         child: BlocBuilder<BirthdaysBloc, BirthdaysState>(
             builder: (context, state) {
           return Scaffold(

--- a/lib/page/main_page/main_page.dart
+++ b/lib/page/main_page/main_page.dart
@@ -8,7 +8,7 @@ import 'package:birthday_calendar/page/birthdays_for_calendar_day_page/birthdays
 import 'package:birthday_calendar/service/contacts_service/contacts_service.dart';
 import 'package:birthday_calendar/service/notification_service/notificationCallbacks.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
-import 'package:birthday_calendar/service/storage_service/shared_preferences_storage.dart';
+import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:birthday_calendar/service/update_service/update_service.dart';
 import 'package:birthday_calendar/service/update_service/update_service_impl.dart';
 import 'package:birthday_calendar/service/version_specific_service/VersionSpecificService.dart';
@@ -112,7 +112,7 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
   void initState() {
     super.initState();
     versionSpecificService = new VersionSpecificServiceImpl(
-        storageService: context.read<StorageServiceSharedPreferences>(),
+        storageService: context.read<StorageService>(),
         notificationService: notificationService);
 
     unawaited(_initializeServices());
@@ -246,7 +246,7 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
 
   @override
   void dispose() {
-    context.read<StorageServiceSharedPreferences>().dispose();
+    context.read<StorageService>().dispose();
     widget.notificationService.removeListenerForSelectNotificationStream(this);
     super.dispose();
   }
@@ -257,7 +257,7 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
       UserBirthday? birthday = Utils.getUserBirthdayFromPayload(payload);
       if (birthday != null) {
         List<UserBirthday> birthdays = await context
-            .read<StorageServiceSharedPreferences>()
+            .read<StorageService>()
             .getBirthdaysForDate(birthday.birthdayDate, true);
 
         if (!mounted) return;

--- a/lib/widget/add_birthday_form.dart
+++ b/lib/widget/add_birthday_form.dart
@@ -1,7 +1,7 @@
 import 'package:birthday_calendar/BirthdayBloc/BirthdaysBloc.dart';
 import 'package:birthday_calendar/model/user_birthday.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
-import 'package:birthday_calendar/service/storage_service/shared_preferences_storage.dart';
+import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl_phone_number_input/intl_phone_number_input.dart';
@@ -60,7 +60,7 @@ class AddBirthdayFormState extends State<AddBirthdayForm> {
   Future<void> _getBirthdaysForDate() async {
     try {
       birthdaysForDate = await context
-          .read<StorageServiceSharedPreferences>()
+          .read<StorageService>()
           .getBirthdaysForDate(widget.dateOfDay, true);
     } catch (e) {
       debugPrint("Failed to fetch birthdays for date: $e");

--- a/lib/widget/calendar_day.dart
+++ b/lib/widget/calendar_day.dart
@@ -1,5 +1,5 @@
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
-import 'package:birthday_calendar/service/storage_service/shared_preferences_storage.dart';
+import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
 import 'package:birthday_calendar/page/birthdays_for_calendar_day_page/birthdays_for_calendar_day.dart';
@@ -26,7 +26,7 @@ class _CalendarDayState extends State<CalendarDayWidget> {
   void initState() {
     unawaited(_fetchBirthdaysFromStorage());
     Stream<List<UserBirthday>> stream =
-        context.read<StorageServiceSharedPreferences>().getBirthdaysStream();
+        context.read<StorageService>().getBirthdaysStream();
     _streamSubscription = stream.listen(_handleEventFromStorageService);
     super.initState();
   }
@@ -61,7 +61,7 @@ class _CalendarDayState extends State<CalendarDayWidget> {
   Future<void> _fetchBirthdaysFromStorage() async {
     try {
       List<UserBirthday> storedBirthdays = await context
-          .read<StorageServiceSharedPreferences>()
+          .read<StorageService>()
           .getBirthdaysForDate(widget.date, true);
 
       if (!mounted) return;

--- a/test/birthday_widget_test.dart
+++ b/test/birthday_widget_test.dart
@@ -63,8 +63,8 @@ void main() {
     });
   });
 
-  Widget base = RepositoryProvider(
-      create: (context) => StorageServiceSharedPreferences(),
+  Widget base = RepositoryProvider<StorageService>.value(
+      value: storageService,
       child: MultiBlocProvider(
         providers: [
           BlocProvider(create: (context) => ThemeBloc(storageService, false)),


### PR DESCRIPTION
Fixes #138 

This pull request refactors the codebase to generalize the use of the `StorageService` interface throughout the application, replacing direct references to the `StorageServiceSharedPreferences` implementation. This change improves maintainability and flexibility by decoupling the app from a specific storage backend. The update affects dependency injection, widget construction, and bloc initialization across the main app, widgets, and tests.

**Refactoring storage service usage:**

* All imports and usages of `StorageServiceSharedPreferences` are replaced with the more generic `StorageService` interface across multiple files, including `main.dart`, widget files, and bloc initializations. This includes updating constructor parameters, repository providers, and bloc dependencies to use `StorageService` instead of the concrete implementation. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L36-R71) [[2]](diffhunk://#diff-9550f6e9473aa6c6dc481755ede70ba28cf9897a161bb6ce6c234d217eae9c2aL6-R6) [[3]](diffhunk://#diff-9550f6e9473aa6c6dc481755ede70ba28cf9897a161bb6ce6c234d217eae9c2aL88-R88) [[4]](diffhunk://#diff-9550f6e9473aa6c6dc481755ede70ba28cf9897a161bb6ce6c234d217eae9c2aL156-R156) [[5]](diffhunk://#diff-4ee38863142f42cc1bd3bdb86d328ba64dc50dff76ea130136a6b7f24dc224e4L6-R6) [[6]](diffhunk://#diff-4ee38863142f42cc1bd3bdb86d328ba64dc50dff76ea130136a6b7f24dc224e4L29-R29) [[7]](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL11-R11) [[8]](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL115-R115) [[9]](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL249-R249) [[10]](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL260-R260) [[11]](diffhunk://#diff-48c78a2fa9cccda960acd60ea28887b4b661c5bc95c830b56d7b4d05d4ad05feL4-R4) [[12]](diffhunk://#diff-48c78a2fa9cccda960acd60ea28887b4b661c5bc95c830b56d7b4d05d4ad05feL63-R63) [[13]](diffhunk://#diff-a36180e169a230abb1a897d3285ec82e4551518b5ec13b8543e4cf2cac1b655fL2-R2) [[14]](diffhunk://#diff-a36180e169a230abb1a897d3285ec82e4551518b5ec13b8543e4cf2cac1b655fL29-R29) [[15]](diffhunk://#diff-a36180e169a230abb1a897d3285ec82e4551518b5ec13b8543e4cf2cac1b655fL64-R64) [[16]](diffhunk://#diff-0668277bf42234efffd770ea5348423c805a7927ce250d18610172d6f1c6a5adL66-R67)

**Widget and app structure updates:**

* The main app widget is renamed from `MyApp` to `BirthdayCalendarApp` and now receives the storage service instance via dependency injection, which is then provided to the widget tree using `RepositoryProvider.value`.

**Testing improvements:**

* The test setup in `birthday_widget_test.dart` now injects a `StorageService` instance using `RepositoryProvider.value`, aligning tests with the new dependency injection pattern.