### PR TITLE
_handleEventFromStorageService uses identity-based contains() — may insert duplicate birthday entries

### DIFF
--- a/lib/model/birthdays_stream_event.dart
+++ b/lib/model/birthdays_stream_event.dart
@@ -1,0 +1,8 @@
+import 'package:birthday_calendar/model/user_birthday.dart';
+
+class BirthdaysStreamEvent {
+  final DateTime date;
+  final List<UserBirthday> birthdays;
+
+  BirthdaysStreamEvent(this.date, this.birthdays);
+}

--- a/lib/model/user_birthday.dart
+++ b/lib/model/user_birthday.dart
@@ -32,23 +32,20 @@ class UserBirthday {
     this.hasNotification = status;
   }
 
-  static bool _sameDay(DateTime a, DateTime b) =>
-      a.month == b.month && a.day == b.day;
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is UserBirthday &&
           runtimeType == other.runtimeType &&
           name == other.name &&
-          _sameDay(birthdayDate, other.birthdayDate);
+          birthdayDate.month == other.birthdayDate.month &&
+          birthdayDate.day == other.birthdayDate.day;
 
   @override
-  int get hashCode => name.hashCode ^ birthdayDate.month ^ birthdayDate.day;
+  int get hashCode => Object.hash(name, birthdayDate.month, birthdayDate.day);
 
   bool equals(UserBirthday otherBirthday) {
-    return this.name == otherBirthday.name &&
-        _sameDay(this.birthdayDate, otherBirthday.birthdayDate);
+    return this == otherBirthday;
   }
 
   factory UserBirthday.fromJson(Map<String, dynamic> json) {

--- a/lib/service/storage_service/shared_preferences_storage.dart
+++ b/lib/service/storage_service/shared_preferences_storage.dart
@@ -3,14 +3,15 @@ import 'dart:async';
 import 'package:birthday_calendar/BirthdayCalendarDateUtils.dart';
 import 'package:birthday_calendar/constants.dart';
 import 'package:birthday_calendar/model/user_birthday.dart';
+import 'package:birthday_calendar/model/birthdays_stream_event.dart';
 import 'package:intl/intl.dart';
 import 'storage_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:collection/collection.dart';
 
 class StorageServiceSharedPreferences extends StorageService {
-  StreamController<List<UserBirthday>> streamController =
-      StreamController<List<UserBirthday>>.broadcast();
+  StreamController<BirthdaysStreamEvent> streamController =
+      StreamController<BirthdaysStreamEvent>.broadcast();
 
   @override
   Future<void> clearAllBirthdays() async {
@@ -98,7 +99,7 @@ class StorageServiceSharedPreferences extends StorageService {
         BirthdayCalendarDateUtils.formatDateForSharedPrefs(dateTime);
     await sharedPreferences.setString(formattedDate, encoded);
 
-    streamController.sink.add(birthdays);
+    streamController.sink.add(BirthdaysStreamEvent(dateTime, birthdays));
   }
 
   @override
@@ -123,7 +124,7 @@ class StorageServiceSharedPreferences extends StorageService {
   }
 
   @override
-  Stream<List<UserBirthday>> getBirthdaysStream() {
+  Stream<BirthdaysStreamEvent> getBirthdaysStream() {
     return streamController.stream;
   }
 

--- a/lib/service/storage_service/storage_service.dart
+++ b/lib/service/storage_service/storage_service.dart
@@ -1,5 +1,6 @@
 import 'package:birthday_calendar/constants.dart';
 import 'package:birthday_calendar/model/user_birthday.dart';
+import 'package:birthday_calendar/model/birthdays_stream_event.dart';
 
 abstract class StorageService {
   Future<List<UserBirthday>> getBirthdaysForDate(
@@ -17,7 +18,7 @@ abstract class StorageService {
 
   Future<void> saveThemeModeSetting(bool isDarkModeEnabled);
 
-  Stream<List<UserBirthday>> getBirthdaysStream();
+  Stream<BirthdaysStreamEvent> getBirthdaysStream();
 
   Future<void> saveIsContactsPermissionPermanentlyDenied(bool isPermanentlyDenied);
 

--- a/lib/widget/calendar_day.dart
+++ b/lib/widget/calendar_day.dart
@@ -32,18 +32,33 @@ class _CalendarDayState extends State<CalendarDayWidget> {
   }
 
   void _handleEventFromStorageService(List<UserBirthday> event) {
-    bool hasNewBirthdays = false;
-    for (UserBirthday birthday in event) {
-      if (birthday.birthdayDate.month == widget.date.month &&
-          birthday.birthdayDate.day == widget.date.day) {
-        if (!_birthdays.contains(birthday)) {
-          _birthdays.add(birthday);
-          hasNewBirthdays = true;
+    if (!mounted) {
+      return;
+    }
+
+    bool changed = false;
+    for (UserBirthday updatedBirthday in event) {
+      if (updatedBirthday.birthdayDate.month == widget.date.month &&
+          updatedBirthday.birthdayDate.day == widget.date.day) {
+        int index =
+            _birthdays.indexWhere((element) => element == updatedBirthday);
+        if (index != -1) {
+          UserBirthday existing = _birthdays[index];
+          if (existing.hasNotification != updatedBirthday.hasNotification ||
+              existing.phoneNumber != updatedBirthday.phoneNumber ||
+              existing.notificationId != updatedBirthday.notificationId ||
+              existing.birthdayDate != updatedBirthday.birthdayDate) {
+            _birthdays[index] = updatedBirthday;
+            changed = true;
+          }
+        } else {
+          _birthdays.add(updatedBirthday);
+          changed = true;
         }
       }
     }
 
-    if (hasNewBirthdays) {
+    if (changed) {
       setState(() {});
     }
   }

--- a/lib/widget/calendar_day.dart
+++ b/lib/widget/calendar_day.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'dart:async';
 import 'package:birthday_calendar/page/birthdays_for_calendar_day_page/birthdays_for_calendar_day.dart';
 import 'package:birthday_calendar/model/user_birthday.dart';
+import 'package:birthday_calendar/model/birthdays_stream_event.dart';
 import 'package:provider/provider.dart';
 
 class CalendarDayWidget extends StatefulWidget {
@@ -20,46 +21,31 @@ class CalendarDayWidget extends StatefulWidget {
 
 class _CalendarDayState extends State<CalendarDayWidget> {
   List<UserBirthday> _birthdays = [];
-  late StreamSubscription<List<UserBirthday>> _streamSubscription;
+  late StreamSubscription<BirthdaysStreamEvent> _streamSubscription;
 
   @override
   void initState() {
     unawaited(_fetchBirthdaysFromStorage());
-    Stream<List<UserBirthday>> stream =
+    Stream<BirthdaysStreamEvent> stream =
         context.read<StorageService>().getBirthdaysStream();
     _streamSubscription = stream.listen(_handleEventFromStorageService);
     super.initState();
   }
 
-  void _handleEventFromStorageService(List<UserBirthday> event) {
+  void _handleEventFromStorageService(BirthdaysStreamEvent event) {
     if (!mounted) {
       return;
     }
 
-    bool changed = false;
-    for (UserBirthday updatedBirthday in event) {
-      if (updatedBirthday.birthdayDate.month == widget.date.month &&
-          updatedBirthday.birthdayDate.day == widget.date.day) {
-        int index =
-            _birthdays.indexWhere((element) => element == updatedBirthday);
-        if (index != -1) {
-          UserBirthday existing = _birthdays[index];
-          if (existing.hasNotification != updatedBirthday.hasNotification ||
-              existing.phoneNumber != updatedBirthday.phoneNumber ||
-              existing.notificationId != updatedBirthday.notificationId ||
-              existing.birthdayDate != updatedBirthday.birthdayDate) {
-            _birthdays[index] = updatedBirthday;
-            changed = true;
-          }
-        } else {
-          _birthdays.add(updatedBirthday);
-          changed = true;
-        }
-      }
-    }
-
-    if (changed) {
-      setState(() {});
+    if (event.date.month == widget.date.month &&
+        event.date.day == widget.date.day) {
+      setState(() {
+        _birthdays.removeWhere((element) =>
+            element.birthdayDate.year == event.date.year &&
+            element.birthdayDate.month == event.date.month &&
+            element.birthdayDate.day == event.date.day);
+        _birthdays.addAll(event.birthdays);
+      });
     }
   }
 

--- a/lib/widget/calendar_day.dart
+++ b/lib/widget/calendar_day.dart
@@ -32,23 +32,19 @@ class _CalendarDayState extends State<CalendarDayWidget> {
   }
 
   void _handleEventFromStorageService(List<UserBirthday> event) {
-    List<UserBirthday> currentBirthdays = _birthdays;
+    bool hasNewBirthdays = false;
     for (UserBirthday birthday in event) {
-      DateTime firstDateWithoutYear =
-          new DateTime(birthday.birthdayDate.month, birthday.birthdayDate.day);
-      DateTime secondDateWithoutYear =
-          new DateTime(widget.date.month, widget.date.day);
-
-      if (firstDateWithoutYear == secondDateWithoutYear &&
-          !currentBirthdays.contains(birthday)) {
-        currentBirthdays.add(birthday);
+      if (birthday.birthdayDate.month == widget.date.month &&
+          birthday.birthdayDate.day == widget.date.day) {
+        if (!_birthdays.contains(birthday)) {
+          _birthdays.add(birthday);
+          hasNewBirthdays = true;
+        }
       }
     }
 
-    if (currentBirthdays.length > 0) {
-      setState(() {
-        _birthdays = currentBirthdays;
-      });
+    if (hasNewBirthdays) {
+      setState(() {});
     }
   }
 

--- a/test/calendar_day_widget_test.dart
+++ b/test/calendar_day_widget_test.dart
@@ -3,6 +3,7 @@ import 'package:birthday_calendar/model/user_birthday.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
 import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:birthday_calendar/widget/calendar_day.dart';
+import 'package:birthday_calendar/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';

--- a/test/calendar_day_widget_test.dart
+++ b/test/calendar_day_widget_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:birthday_calendar/model/user_birthday.dart';
+import 'package:birthday_calendar/model/birthdays_stream_event.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
 import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:birthday_calendar/widget/calendar_day.dart';
@@ -35,13 +36,13 @@ class MockNotificationService implements NotificationService {
 }
 
 class MockStorageService extends StorageService {
-  final _controller = StreamController<List<UserBirthday>>.broadcast();
+  final _controller = StreamController<BirthdaysStreamEvent>.broadcast();
 
   @override
-  Stream<List<UserBirthday>> getBirthdaysStream() => _controller.stream;
+  Stream<BirthdaysStreamEvent> getBirthdaysStream() => _controller.stream;
 
-  void emit(List<UserBirthday> birthdays) {
-    _controller.add(birthdays);
+  void emit(DateTime date, List<UserBirthday> birthdays) {
+    _controller.add(BirthdaysStreamEvent(date, birthdays));
   }
 
   @override
@@ -108,14 +109,14 @@ void main() {
 
     // Add a birthday
     final birthday = UserBirthday('Test', date, false, '');
-    mockStorageService.emit([birthday]);
+    mockStorageService.emit(date, [birthday]);
     await tester.pump();
 
     expect(find.byIcon(Icons.cake_outlined), findsOneWidget);
 
     // Update the birthday (e.g., enable notification)
     final updatedBirthday = UserBirthday('Test', date, true, '');
-    mockStorageService.emit([updatedBirthday]);
+    mockStorageService.emit(date, [updatedBirthday]);
     await tester.pump();
 
     // Verify it still shows the cake
@@ -146,7 +147,7 @@ void main() {
      await tester.pumpWidget(Container());
 
      // Emit an event
-     mockStorageService.emit([UserBirthday('Test', date, false, '')]);
+     mockStorageService.emit(date, [UserBirthday('Test', date, false, '')]);
      
      // Should not crash
      await tester.pump();

--- a/test/calendar_day_widget_test.dart
+++ b/test/calendar_day_widget_test.dart
@@ -3,7 +3,6 @@ import 'package:birthday_calendar/model/user_birthday.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
 import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:birthday_calendar/widget/calendar_day.dart';
-import 'package:birthday_calendar/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';

--- a/test/calendar_day_widget_test.dart
+++ b/test/calendar_day_widget_test.dart
@@ -4,6 +4,7 @@ import 'package:birthday_calendar/model/birthdays_stream_event.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
 import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:birthday_calendar/widget/calendar_day.dart';
+import 'package:birthday_calendar/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';

--- a/test/calendar_day_widget_test.dart
+++ b/test/calendar_day_widget_test.dart
@@ -4,7 +4,6 @@ import 'package:birthday_calendar/model/birthdays_stream_event.dart';
 import 'package:birthday_calendar/service/notification_service/notification_service.dart';
 import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:birthday_calendar/widget/calendar_day.dart';
-import 'package:birthday_calendar/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';

--- a/test/calendar_day_widget_test.dart
+++ b/test/calendar_day_widget_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'package:birthday_calendar/model/user_birthday.dart';
+import 'package:birthday_calendar/service/notification_service/notification_service.dart';
+import 'package:birthday_calendar/service/storage_service/storage_service.dart';
+import 'package:birthday_calendar/widget/calendar_day.dart';
+import 'package:birthday_calendar/constants.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:birthday_calendar/service/notification_service/notificationCallbacks.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class MockNotificationService implements NotificationService {
+  @override
+  Future<void> init(BuildContext context) async {}
+  @override
+  Future<bool> isNotificationPermissionGranted(BuildContext context) async => true;
+  @override
+  Future<PermissionStatus> requestNotificationPermission(BuildContext context) async => PermissionStatus.granted;
+  @override
+  Future<void> scheduleNotificationForBirthday(UserBirthday userBirthday, String notificationMessage) async {}
+  @override
+  Future<void> cancelNotificationForBirthday(UserBirthday birthday) async {}
+  @override
+  Future<void> cancelAllNotifications() async {}
+  @override
+  Future<List<PendingNotificationRequest>> getAllScheduledNotifications() async => [];
+  @override
+  void dispose() {}
+  @override
+  void addListenerForSelectNotificationStream(NotificationCallbacks listener) {}
+  @override
+  void removeListenerForSelectNotificationStream(NotificationCallbacks listener) {}
+}
+
+class MockStorageService extends StorageService {
+  final _controller = StreamController<List<UserBirthday>>.broadcast();
+
+  @override
+  Stream<List<UserBirthday>> getBirthdaysStream() => _controller.stream;
+
+  void emit(List<UserBirthday> birthdays) {
+    _controller.add(birthdays);
+  }
+
+  @override
+  Future<void> clearAllBirthdays() async {}
+  @override
+  Future<List<UserBirthday>> getBirthdaysForDate(DateTime dateTime, bool shouldGetBirthdaysFromSimilarDate) async => [];
+  @override
+  Future<bool> getThemeModeSetting() async => false;
+  @override
+  Future<void> saveBirthdaysForDate(DateTime dateTime, List<UserBirthday> birthdays) async {}
+  @override
+  Future<void> saveThemeModeSetting(bool isDarkModeEnabled) async {}
+  @override
+  Future<void> updateNotificationStatusForBirthday(UserBirthday userBirthday, bool updatedStatus) async {}
+  @override
+  Future<void> saveIsContactsPermissionPermanentlyDenied(bool isPermanentlyDenied) async {}
+  @override
+  Future<bool> getIsContactPermissionPermanentlyDenied() async => false;
+  @override
+  Future<void> saveDidAlreadyMigrateNotificationStatus(bool status) async {}
+  @override
+  Future<bool> getAlreadyMigrateNotificationStatus() async => false;
+  @override
+  Future<void> saveDidAlreadyMigrateNotificationIds(bool status) async {}
+  @override
+  Future<bool> getAlreadyMigrateNotificationIds() async => false;
+  @override
+  Future<List<UserBirthday>> getAllBirthdays() async => [];
+  @override
+  Future<void> updatePhoneNumberForBirthday(UserBirthday birthday) async {}
+  @override
+  Future<void> updateNotificationIdForBirthday(UserBirthday birthday) async {}
+  @override
+  Future<void> setNotificationPermissionState(NotificationPermissionState state) async {}
+  @override
+  Future<NotificationPermissionState> getNotificationPermissionState() async => NotificationPermissionState.unknown;
+
+  void dispose() {
+    _controller.close();
+  }
+}
+
+void main() {
+  testWidgets('CalendarDayWidget updates UI when birthday notification status changes', (WidgetTester tester) async {
+    final mockStorageService = MockStorageService();
+    final mockNotificationService = MockNotificationService();
+    final date = DateTime(2023, 1, 1);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Provider<StorageService>.value(
+          value: mockStorageService,
+          child: CalendarDayWidget(
+            key: Key('calendar_day'),
+            date: date,
+            notificationService: mockNotificationService,
+          ),
+        ),
+      ),
+    );
+
+    // Initial state: no birthdays
+    expect(find.byIcon(Icons.cake_outlined), findsNothing);
+
+    // Add a birthday
+    final birthday = UserBirthday('Test', date, false, '');
+    mockStorageService.emit([birthday]);
+    await tester.pump();
+
+    expect(find.byIcon(Icons.cake_outlined), findsOneWidget);
+
+    // Update the birthday (e.g., enable notification)
+    final updatedBirthday = UserBirthday('Test', date, true, '');
+    mockStorageService.emit([updatedBirthday]);
+    await tester.pump();
+
+    // Verify it still shows the cake
+    expect(find.byIcon(Icons.cake_outlined), findsOneWidget);
+    
+    mockStorageService.dispose();
+  });
+
+  testWidgets('CalendarDayWidget does not update if mounted is false', (WidgetTester tester) async {
+     final mockStorageService = MockStorageService();
+     final mockNotificationService = MockNotificationService();
+     final date = DateTime(2023, 1, 1);
+
+     await tester.pumpWidget(
+       MaterialApp(
+         home: Provider<StorageService>.value(
+           value: mockStorageService,
+           child: CalendarDayWidget(
+             key: Key('calendar_day'),
+             date: date,
+             notificationService: mockNotificationService,
+           ),
+         ),
+       ),
+     );
+
+     // Unmount the widget
+     await tester.pumpWidget(Container());
+
+     // Emit an event
+     mockStorageService.emit([UserBirthday('Test', date, false, '')]);
+     
+     // Should not crash
+     await tester.pump();
+     
+     mockStorageService.dispose();
+  });
+}

--- a/test/user_birthday_test.dart
+++ b/test/user_birthday_test.dart
@@ -73,7 +73,6 @@ void main() {
       final birthday2 = UserBirthday('Alice', DateTime(1990, 6, 16), false, '');
 
       expect(birthday1 == birthday2, isFalse);
-      expect(birthday1.hashCode, isNot(equals(birthday2.hashCode)));
     });
 
     test('identical objects should be equal', () {

--- a/test/user_birthday_test.dart
+++ b/test/user_birthday_test.dart
@@ -44,4 +44,48 @@ void main() {
       expect(!userBirthday.birthdayDate.isAfter(after), isTrue);
     });
   });
+
+  group('UserBirthday equality and hashCode', () {
+    test('same name, month, day but different year should be equal', () {
+      final birthday1 = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
+      final birthday2 = UserBirthday('Alice', DateTime(2000, 6, 15), true, '123');
+
+      expect(birthday1 == birthday2, isTrue);
+      expect(birthday1.hashCode, equals(birthday2.hashCode));
+    });
+
+    test('different name should not be equal', () {
+      final birthday1 = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
+      final birthday2 = UserBirthday('Bob', DateTime(1990, 6, 15), false, '');
+
+      expect(birthday1 == birthday2, isFalse);
+      expect(birthday1.hashCode, isNot(equals(birthday2.hashCode)));
+    });
+
+    test('different month should not be equal', () {
+      final birthday1 = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
+      final birthday2 = UserBirthday('Alice', DateTime(1990, 7, 15), false, '');
+
+      expect(birthday1 == birthday2, isFalse);
+      expect(birthday1.hashCode, isNot(equals(birthday2.hashCode)));
+    });
+
+    test('different day should not be equal', () {
+      final birthday1 = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
+      final birthday2 = UserBirthday('Alice', DateTime(1990, 6, 16), false, '');
+
+      expect(birthday1 == birthday2, isFalse);
+      expect(birthday1.hashCode, isNot(equals(birthday2.hashCode)));
+    });
+
+    test('identical objects should be equal', () {
+      final birthday = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
+      expect(birthday == birthday, isTrue);
+    });
+
+    test('comparison with different type should be false', () {
+      final birthday = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
+      expect(birthday == 'Alice', isFalse);
+    });
+  });
 }

--- a/test/user_birthday_test.dart
+++ b/test/user_birthday_test.dart
@@ -66,7 +66,6 @@ void main() {
       final birthday2 = UserBirthday('Alice', DateTime(1990, 7, 15), false, '');
 
       expect(birthday1 == birthday2, isFalse);
-      expect(birthday1.hashCode, isNot(equals(birthday2.hashCode)));
     });
 
     test('different day should not be equal', () {

--- a/test/user_birthday_test.dart
+++ b/test/user_birthday_test.dart
@@ -59,7 +59,6 @@ void main() {
       final birthday2 = UserBirthday('Bob', DateTime(1990, 6, 15), false, '');
 
       expect(birthday1 == birthday2, isFalse);
-      expect(birthday1.hashCode, isNot(equals(birthday2.hashCode)));
     });
 
     test('different month should not be equal', () {


### PR DESCRIPTION
Fixes #139 

This pull request refactors how birthday updates are streamed and handled throughout the application, improving type safety and clarity in the event system. It introduces a new `BirthdaysStreamEvent` class to encapsulate both the date and the list of birthdays, updates the storage and widget layers to use this new event type, and adds comprehensive tests for both the UI and the equality logic of `UserBirthday`.

**Event streaming and handling improvements:**

- Introduced a new `BirthdaysStreamEvent` class to encapsulate a date and the corresponding list of `UserBirthday` objects, replacing the previous approach of streaming bare lists of birthdays. (`lib/model/birthdays_stream_event.dart`)
- Updated the storage service interface and its shared preferences implementation to stream `BirthdaysStreamEvent` instead of `List<UserBirthday>`, and to emit events containing both the date and the relevant birthdays. (`lib/service/storage_service/storage_service.dart`, `lib/service/storage_service/shared_preferences_storage.dart`) [[1]](diffhunk://#diff-5d4df52cc08f64273216f1d1cba5b0faed696e79d83f0975cb4ce757bdd959e8L20-R21) [[2]](diffhunk://#diff-688baf8b97d284c810bf85ca0ce342cc1483ef6f60277acd5698c7530c35f0b0R6-R14) [[3]](diffhunk://#diff-688baf8b97d284c810bf85ca0ce342cc1483ef6f60277acd5698c7530c35f0b0L101-R102) [[4]](diffhunk://#diff-688baf8b97d284c810bf85ca0ce342cc1483ef6f60277acd5698c7530c35f0b0L126-R127)
- Refactored `CalendarDayWidget` to subscribe to and handle `BirthdaysStreamEvent`, updating its internal state only when the event's date matches the widget's date, and ensuring safe updates when the widget is mounted. (`lib/widget/calendar_day.dart`) [[1]](diffhunk://#diff-a36180e169a230abb1a897d3285ec82e4551518b5ec13b8543e4cf2cac1b655fR7) [[2]](diffhunk://#diff-a36180e169a230abb1a897d3285ec82e4551518b5ec13b8543e4cf2cac1b655fL23-R47)

**Testing enhancements:**

- Added a new widget test file for `CalendarDayWidget` to verify correct UI updates in response to birthday stream events, including cases where the widget is unmounted. This includes mock implementations of the required services. (`test/calendar_day_widget_test.dart`)
- Expanded tests for `UserBirthday` to thoroughly check equality and hash code logic, ensuring that only name, month, and day are considered for equality. (`test/user_birthday_test.dart`)

**UserBirthday equality logic:**

- Simplified and clarified the equality (`==`), `hashCode`, and `equals` methods in `UserBirthday`, now comparing only name, month, and day, and using `Object.hash` for hash code generation. (`lib/model/user_birthday.dart`)