### PR TITLE
_isVersionGreaterThan version comparison is incorrect for versions with unequal segment counts

### DIFF
--- a/lib/service/version_specific_service/VersionSpecificServiceImpl.dart
+++ b/lib/service/version_specific_service/VersionSpecificServiceImpl.dart
@@ -8,6 +8,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter/foundation.dart';
 import 'dart:convert';
 import 'package:collection/collection.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 class VersionSpecificServiceImpl extends VersionSpecificService {
   VersionSpecificServiceImpl(
@@ -109,16 +110,21 @@ class VersionSpecificServiceImpl extends VersionSpecificService {
   }
 
   bool _isVersionGreaterThan(String newVersion, String currentVersion) {
-    List<String> currentVersionSplit = currentVersion.split(".");
-    List<String> newVersionSplit = newVersion.split(".");
-    bool isNewVersionGreaterThanCurrentVersion = false;
-    for (var i = 0; i < currentVersionSplit.length; i++) {
-      isNewVersionGreaterThanCurrentVersion =
-          int.parse(newVersionSplit[i]) > int.parse(currentVersionSplit[i]);
-      if (int.parse(newVersionSplit[i]) != int.parse(currentVersionSplit[i])) {
-        break;
-      }
+    try {
+      return Version.parse(_ensureThreeSegments(newVersion)) >
+          Version.parse(_ensureThreeSegments(currentVersion));
+    } catch (e) {
+      return false;
     }
-    return isNewVersionGreaterThanCurrentVersion;
+  }
+
+  String _ensureThreeSegments(String v) {
+    final parts = v.split('+');
+    final dotParts = parts[0].split('.');
+    while (dotParts.length < 3) {
+      dotParts.add('0');
+    }
+    return dotParts.take(3).join('.') +
+        (parts.length > 1 ? '+${parts[1]}' : '');
   }
 }

--- a/lib/service/version_specific_service/VersionSpecificServiceImpl.dart
+++ b/lib/service/version_specific_service/VersionSpecificServiceImpl.dart
@@ -28,9 +28,9 @@ class VersionSpecificServiceImpl extends VersionSpecificService {
     PackageInfo packageInfo = await PackageInfo.fromPlatform();
     if (_isVersionGreaterThan(
         packageInfo.version, versionToMigrateNotificationStatusFrom)) {
-      List<PendingNotificationRequest> pendingNotifications =
+      List<PendingNotificationRequest> scheduledNotifications =
           await notificationService.getAllScheduledNotifications();
-      for (PendingNotificationRequest request in pendingNotifications) {
+      for (PendingNotificationRequest request in scheduledNotifications) {
         if (request.payload != null) {
           String payload = request.payload!;
           UserBirthday userBirthday =
@@ -38,10 +38,10 @@ class VersionSpecificServiceImpl extends VersionSpecificService {
           if (!userBirthday.hasNotification) {
             List<UserBirthday> birthdays = await storageService
                 .getBirthdaysForDate(userBirthday.birthdayDate, false);
-            UserBirthday? found = birthdays
+            UserBirthday? matchedBirthday = birthdays
                 .firstWhereOrNull((element) => element.equals(userBirthday));
-            if (found != null) {
-              birthdays.remove(found);
+            if (matchedBirthday != null) {
+              birthdays.remove(matchedBirthday);
               userBirthday.updateNotificationStatus(true);
               birthdays.add(userBirthday);
               await storageService.saveBirthdaysForDate(
@@ -75,7 +75,7 @@ class VersionSpecificServiceImpl extends VersionSpecificService {
     // Reschedule each birthday with a new deterministic ID.
     // Errors are caught per-item so a single failure doesn't leave all other
     // birthdays without notifications.
-    bool allSucceeded = true;
+    bool isMigrationSuccessful = true;
     for (UserBirthday birthday in allBirthdays) {
       final migratedBirthday = UserBirthday(
         birthday.name,
@@ -96,7 +96,7 @@ class VersionSpecificServiceImpl extends VersionSpecificService {
           );
         }
       } catch (e, stackTrace) {
-        allSucceeded = false;
+        isMigrationSuccessful = false;
         debugPrint(
             'Failed to migrate birthday ${birthday.name}: $e\n$stackTrace');
       }
@@ -104,27 +104,59 @@ class VersionSpecificServiceImpl extends VersionSpecificService {
 
     // Only mark migration complete if every birthday was migrated successfully,
     // so a partial failure retries on the next launch.
-    if (allSucceeded) {
+    if (isMigrationSuccessful) {
       await storageService.saveDidAlreadyMigrateNotificationIds(true);
     }
   }
 
-  bool _isVersionGreaterThan(String newVersion, String currentVersion) {
+  bool _isVersionGreaterThan(String version, String threshold) {
+    Version? parsedVersion = _tryParseVersion(version);
+    Version? parsedThreshold = _tryParseVersion(threshold);
+
+    if (parsedVersion != null && parsedThreshold != null) {
+      return parsedVersion > parsedThreshold;
+    }
+
+    debugPrint(
+        "Could not compare versions: version='$version', threshold='$threshold'");
+    return false;
+  }
+
+  Version? _tryParseVersion(String versionString) {
     try {
-      return Version.parse(_ensureThreeSegments(newVersion)) >
-          Version.parse(_ensureThreeSegments(currentVersion));
-    } catch (e) {
-      return false;
+      return Version.parse(versionString);
+    } catch (_) {
+      try {
+        return Version.parse(_normalizeToSemVer(versionString));
+      } catch (e) {
+        debugPrint("Failed to parse version '$versionString': $e");
+        return null;
+      }
     }
   }
 
-  String _ensureThreeSegments(String v) {
-    final parts = v.split('+');
-    final dotParts = parts[0].split('.');
-    while (dotParts.length < 3) {
-      dotParts.add('0');
+  String _normalizeToSemVer(String versionString) {
+    int dashIndex = versionString.indexOf('-');
+    int plusIndex = versionString.indexOf('+');
+    int splitIndex = -1;
+
+    if (dashIndex != -1 && plusIndex != -1) {
+      splitIndex = dashIndex < plusIndex ? dashIndex : plusIndex;
+    } else {
+      splitIndex = dashIndex != -1 ? dashIndex : plusIndex;
     }
-    return dotParts.take(3).join('.') +
-        (parts.length > 1 ? '+${parts[1]}' : '');
+
+    String versionPart =
+        splitIndex == -1 ? versionString : versionString.substring(0, splitIndex);
+    String suffix = splitIndex == -1 ? "" : versionString.substring(splitIndex);
+
+    List<String> segments = versionPart.split('.');
+    if (segments.length < 3) {
+      while (segments.length < 3) {
+        segments.add("0");
+      }
+      return segments.join('.') + suffix;
+    }
+    return versionString;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -461,6 +461,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  pub_semver:
+    dependency: "direct main"
+    description:
+      name: pub_semver
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   provider: 6.0.2
   in_app_update: 4.2.5
   flutter_bloc: 8.1.5
+  pub_semver: ^2.2.0
 
 
 dev_dependencies:


### PR DESCRIPTION
Fixes #147 

This pull request improves version comparison logic in the `VersionSpecificServiceImpl` class by leveraging the `pub_semver` package, which provides robust semantic version parsing and comparison. The previous manual comparison logic has been replaced with a more reliable approach, and a helper method ensures version strings are correctly formatted before comparison. The necessary dependency has also been added to `pubspec.yaml`.

**Dependency and version comparison improvements:**

* Added the `pub_semver` package as a dependency in `pubspec.yaml` to enable semantic version parsing and comparison.
* Updated the `_isVersionGreaterThan` method in `VersionSpecificServiceImpl` to use `Version.parse` from `pub_semver` for safer and more accurate version comparison, replacing the manual split-and-compare logic.
* Introduced the `_ensureThreeSegments` helper method to standardize version strings to three segments before parsing, ensuring compatibility with semantic versioning.
* Imported `pub_semver` in `VersionSpecificServiceImpl.dart` to support the new version comparison logic.