### PR TITLE
BLoC state uses raw bool — semantics are opaque and one-shot side-effects are modelled as state

### DIFF
--- a/lib/ClearNotificationsBloc/ClearNotificationsBloc.dart
+++ b/lib/ClearNotificationsBloc/ClearNotificationsBloc.dart
@@ -2,21 +2,27 @@ import 'package:birthday_calendar/service/notification_service/notification_serv
 import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-enum ClearNotificationsEvent { ClearedNotifications }
+abstract class ClearNotificationsEvent {}
 
-class ClearNotificationsBloc extends Bloc<ClearNotificationsEvent, bool> {
+class ClearNotificationsRequested extends ClearNotificationsEvent {}
 
+sealed class ClearNotificationsState {}
+
+class ClearNotificationsInitial extends ClearNotificationsState {}
+
+class ClearNotificationsCompleted extends ClearNotificationsState {}
+
+class ClearNotificationsBloc
+    extends Bloc<ClearNotificationsEvent, ClearNotificationsState> {
   final StorageService storageService;
   final NotificationService notificationService;
 
   ClearNotificationsBloc(this.storageService, this.notificationService)
-      : super(false) {
-    on<ClearNotificationsEvent>((event, emit) async {
-      if (event == ClearNotificationsEvent.ClearedNotifications) {
-        await storageService.clearAllBirthdays();
-        await notificationService.cancelAllNotifications();
-        emit(true);
-      }
+      : super(ClearNotificationsInitial()) {
+    on<ClearNotificationsRequested>((event, emit) async {
+      await storageService.clearAllBirthdays();
+      await notificationService.cancelAllNotifications();
+      emit(ClearNotificationsCompleted());
     });
   }
 }

--- a/lib/UserNotificationStatusBloc/UserNotificationStatusBloc.dart
+++ b/lib/UserNotificationStatusBloc/UserNotificationStatusBloc.dart
@@ -3,36 +3,50 @@ import 'package:birthday_calendar/service/notification_service/notification_serv
 import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class UserNotificationStatusEvent {
-  UserNotificationStatusEvent(
-      {required this.userBirthday,
-      required this.hasNotification,
-      required this.notificationMsg});
+abstract class UserNotificationStatusEvent {}
+
+class UserNotificationStatusToggled extends UserNotificationStatusEvent {
+  UserNotificationStatusToggled(
+      {required this.userBirthday, required this.notificationMsg});
 
   final UserBirthday userBirthday;
-  final bool hasNotification;
   final String notificationMsg;
 }
 
+sealed class UserNotificationStatusState {
+  final bool hasNotification;
+  UserNotificationStatusState(this.hasNotification);
+}
+
+class UserNotificationStatusInitial extends UserNotificationStatusState {
+  UserNotificationStatusInitial(super.hasNotification);
+}
+
+class UserNotificationStatusChanged extends UserNotificationStatusState {
+  UserNotificationStatusChanged(super.hasNotification);
+}
+
 class UserNotificationStatusBloc
-    extends Bloc<UserNotificationStatusEvent, bool> {
+    extends Bloc<UserNotificationStatusEvent, UserNotificationStatusState> {
+  final StorageService storageService;
+  final NotificationService notificationService;
+
   UserNotificationStatusBloc(
-      StorageService storageService, NotificationService notificationService)
-      : super(false) {
-    on<UserNotificationStatusEvent>((event, emit) async {
-      bool notificationStatus = event.hasNotification;
-      notificationStatus = !notificationStatus;
+      this.storageService, this.notificationService, bool initialStatus)
+      : super(UserNotificationStatusInitial(initialStatus)) {
+    on<UserNotificationStatusToggled>((event, emit) async {
+      bool newStatus = !state.hasNotification;
       UserBirthday birthday = event.userBirthday;
-      birthday.hasNotification = notificationStatus;
+      birthday.hasNotification = newStatus;
       await storageService.updateNotificationStatusForBirthday(
-          birthday, notificationStatus);
-      if (!notificationStatus) {
+          birthday, newStatus);
+      if (!newStatus) {
         await notificationService.cancelNotificationForBirthday(birthday);
       } else {
         await notificationService.scheduleNotificationForBirthday(
             birthday, event.notificationMsg);
       }
-      emit(notificationStatus);
+      emit(UserNotificationStatusChanged(newStatus));
     });
   }
 }

--- a/lib/page/birthday/birthday.dart
+++ b/lib/page/birthday/birthday.dart
@@ -155,18 +155,20 @@ class _BirthdayWidgetState extends State<BirthdayWidget> {
           BlocProvider(
               create: (context) => UserNotificationStatusBloc(
                   context.read<StorageService>(),
-                  notificationService),
-              child: BlocBuilder<UserNotificationStatusBloc, bool>(
+                  notificationService,
+                  birthdayOfPerson.hasNotification),
+              child: BlocBuilder<UserNotificationStatusBloc,
+                      UserNotificationStatusState>(
                   builder: (context, state) {
                 return new IconButton(
                     icon: Icon(
-                        !birthdayOfPerson.hasNotification
+                        !state.hasNotification
                             ? Icons.notifications_off_outlined
                             : Icons.notifications_active_outlined,
                         color: Utils.getColorBasedOnPosition(
                             indexOfBirthday, ElementType.icon)),
                     onPressed: () async {
-                      if (!birthdayOfPerson.hasNotification) {
+                      if (!state.hasNotification) {
                         final userNotificationStatusBloc =
                             BlocProvider.of<UserNotificationStatusBloc>(
                                 context);
@@ -178,9 +180,8 @@ class _BirthdayWidgetState extends State<BirthdayWidget> {
 
                         if (status.isGranted) {
                           userNotificationStatusBloc
-                              .add(UserNotificationStatusEvent(
+                              .add(UserNotificationStatusToggled(
                             userBirthday: birthdayOfPerson,
-                            hasNotification: birthdayOfPerson.hasNotification,
                             notificationMsg: localizations
                                 .notificationForBirthdayMessage(
                                     birthdayOfPerson.name),
@@ -199,13 +200,12 @@ class _BirthdayWidgetState extends State<BirthdayWidget> {
                           return;
                         }
 
-                        Utils.showSnackbarWithMessage(
-                            context, localizations.notificationPermissionDenied);
+                        Utils.showSnackbarWithMessage(context,
+                            localizations.notificationPermissionDenied);
                       } else {
                         BlocProvider.of<UserNotificationStatusBloc>(context)
-                            .add(UserNotificationStatusEvent(
+                            .add(UserNotificationStatusToggled(
                           userBirthday: birthdayOfPerson,
-                          hasNotification: birthdayOfPerson.hasNotification,
                           notificationMsg: AppLocalizations.of(context)!
                               .notificationForBirthdayMessage(
                                   birthdayOfPerson.name),

--- a/lib/page/main_page/main_page.dart
+++ b/lib/page/main_page/main_page.dart
@@ -171,7 +171,7 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<ClearNotificationsBloc, bool>(builder: (context, state) {
+    return BlocBuilder<ClearNotificationsBloc, ClearNotificationsState>(builder: (context, state) {
       return Scaffold(
           appBar: AppBar(
             actions: [
@@ -189,9 +189,9 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
               )
             ],
           ),
-          body: BlocListener<ClearNotificationsBloc, bool>(
+          body: BlocListener<ClearNotificationsBloc, ClearNotificationsState>(
             listener: (context, state) {
-              if (state) {
+              if (state is ClearNotificationsCompleted) {
                 setState(() {});
               }
             },

--- a/lib/page/settings_page/settings_screen.dart
+++ b/lib/page/settings_page/settings_screen.dart
@@ -91,7 +91,7 @@ class SettingsScreen extends StatelessWidget {
         TextButton(
           onPressed: () {
             BlocProvider.of<ClearNotificationsBloc>(context)
-                .add(ClearNotificationsEvent.ClearedNotifications);
+                .add(ClearNotificationsRequested());
             Navigator.pop(context);
           },
           child: Text(AppLocalizations.of(context)!.yes),


### PR DESCRIPTION
Fixes #148 

This pull request refactors the BLoC (Business Logic Component) implementation for both notification clearing and user notification status toggling. The changes improve type safety, clarity, and maintainability by introducing explicit event and state classes instead of using primitive types. The UI code is updated accordingly to work with the new BLoC structure.

**BLoC Refactoring and State Management Improvements:**

* Refactored `ClearNotificationsBloc`:
  - Replaced the `enum` event with an abstract class and a specific `ClearNotificationsRequested` event.
  - Introduced explicit state classes: `ClearNotificationsInitial` and `ClearNotificationsCompleted`.
  - Updated the BLoC to emit these new states instead of a boolean.
  - Updated UI components in `main_page.dart` and `settings_screen.dart` to use the new event and state classes. [[1]](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL174-R174) [[2]](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL192-R194) [[3]](diffhunk://#diff-10f972d3afd73c3287216907486f10d442f2d740e37e63474d00c3f7ed33a10cL94-R94)

* Refactored `UserNotificationStatusBloc`:
  - Replaced the previous event class with an abstract base and a specific `UserNotificationStatusToggled` event.
  - Introduced explicit state classes: `UserNotificationStatusInitial` and `UserNotificationStatusChanged`, both carrying the notification status.
  - Updated the BLoC to emit these new states and to use the current state for toggling logic.
  - Updated the birthday page UI to use the new event and state types, removing direct dependency on the model's boolean. [[1]](diffhunk://#diff-9550f6e9473aa6c6dc481755ede70ba28cf9897a161bb6ce6c234d217eae9c2aL158-R171) [[2]](diffhunk://#diff-9550f6e9473aa6c6dc481755ede70ba28cf9897a161bb6ce6c234d217eae9c2aL181-L183) [[3]](diffhunk://#diff-9550f6e9473aa6c6dc481755ede70ba28cf9897a161bb6ce6c234d217eae9c2aL202-L208)