### PR TITLE
BirthdaysState has nullable fields with no sealed class structure to express valid combinations

### DIFF
--- a/lib/BirthdayBloc/BirthdaysBloc.dart
+++ b/lib/BirthdayBloc/BirthdaysBloc.dart
@@ -26,10 +26,9 @@ class BirthdaysEvent {
 class BirthdaysBloc extends Bloc<BirthdaysEvent, BirthdaysState> {
   BirthdaysBloc(NotificationService notificationService,
       StorageService storageService, List<UserBirthday> birthdaysForDate)
-      : super(BirthdaysState(
+      : super(BirthdaysLoaded(
             date: DateTime.now(),
-            birthdays: birthdaysForDate,
-            showAddBirthdayDialog: false)) {
+            birthdays: birthdaysForDate)) {
     on<BirthdaysEvent>((event, emit) async {
       switch (event.eventName) {
         case BirthdayEvent.AddBirthday:
@@ -40,7 +39,7 @@ class BirthdaysBloc extends Bloc<BirthdaysEvent, BirthdaysState> {
               event, emit, storageService, notificationService);
           break;
         case BirthdayEvent.ShowAddBirthdayDialog:
-          emit(new BirthdaysState(showAddBirthdayDialog: true));
+          emit(BirthdaysShowDialog());
           break;
       }
     });
@@ -48,7 +47,7 @@ class BirthdaysBloc extends Bloc<BirthdaysEvent, BirthdaysState> {
 
   Future<void> _handleAddEvent(
       BirthdaysEvent event,
-      Emitter emit,
+      Emitter<BirthdaysState> emit,
       StorageService storageService,
       NotificationService notificationService) async {
     UserBirthday? userBirthday = event.birthday;
@@ -67,15 +66,14 @@ class BirthdaysBloc extends Bloc<BirthdaysEvent, BirthdaysState> {
     await notificationService.scheduleNotificationForBirthday(
         userBirthday, notificationMsg);
 
-    emit(new BirthdaysState(
+    emit(BirthdaysLoaded(
         date: birthdayDate,
-        birthdays: birthdaysMatchingDate,
-        showAddBirthdayDialog: false));
+        birthdays: birthdaysMatchingDate));
   }
 
   Future<void> _handleRemoveEvent(
       BirthdaysEvent event,
-      Emitter emit,
+      Emitter<BirthdaysState> emit,
       StorageService storageService,
       NotificationService notificationService) async {
     UserBirthday? userBirthday = event.birthday;
@@ -95,9 +93,8 @@ class BirthdaysBloc extends Bloc<BirthdaysEvent, BirthdaysState> {
 
     await storageService.saveBirthdaysForDate(birthdayDate, filteredBirthdays);
     await notificationService.cancelNotificationForBirthday(userBirthday);
-    emit(new BirthdaysState(
+    emit(BirthdaysLoaded(
         date: birthdayDate,
-        birthdays: filteredBirthdays,
-        showAddBirthdayDialog: false));
+        birthdays: filteredBirthdays));
   }
 }

--- a/lib/BirthdayBloc/BirthdaysState.dart
+++ b/lib/BirthdayBloc/BirthdaysState.dart
@@ -1,10 +1,12 @@
 import 'package:birthday_calendar/model/user_birthday.dart';
 
-class BirthdaysState {
-  final DateTime? date;
-  final List<UserBirthday>? birthdays;
-  final bool showAddBirthdayDialog;
+sealed class BirthdaysState {}
 
-  BirthdaysState(
-      {this.date, this.birthdays, required this.showAddBirthdayDialog});
+class BirthdaysLoaded extends BirthdaysState {
+  final DateTime date;
+  final List<UserBirthday> birthdays;
+
+  BirthdaysLoaded({required this.date, required this.birthdays});
 }
+
+class BirthdaysShowDialog extends BirthdaysState {}

--- a/lib/page/birthdays_for_calendar_day_page/birthdays_for_calendar_day.dart
+++ b/lib/page/birthdays_for_calendar_day_page/birthdays_for_calendar_day.dart
@@ -43,27 +43,26 @@ class BirthdaysForCalendarDayWidget extends StatelessWidget {
             body: Center(
                 child: Column(
               children: [
-                (state.birthdays == null || state.birthdays!.length == 0)
-                    ? Spacer()
-                    : Expanded(
-                        child: ListView.builder(
-                          itemCount: state.birthdays != null
-                              ? state.birthdays!.length
-                              : 0,
-                          itemBuilder: (BuildContext context, int index) {
-                            return BlocProvider.value(
-                                value: BlocProvider.of<BirthdaysBloc>(context),
-                                child: BirthdayWidget(
-                                    key: Key(state.birthdays![index].name),
-                                    birthdayOfPerson: state.birthdays![index],
-                                    indexOfBirthday: index,
-                                    notificationService: notificationService));
-                          },
-                        ),
-                      ),
+                if (state is BirthdaysLoaded && state.birthdays.isNotEmpty)
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: state.birthdays.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return BlocProvider.value(
+                            value: BlocProvider.of<BirthdaysBloc>(context),
+                            child: BirthdayWidget(
+                                key: Key(state.birthdays[index].name),
+                                birthdayOfPerson: state.birthdays[index],
+                                indexOfBirthday: index,
+                                notificationService: notificationService));
+                      },
+                    ),
+                  )
+                else
+                  Spacer(),
                 BlocListener<BirthdaysBloc, BirthdaysState>(
                   listener: (context, state) {
-                    if (state.showAddBirthdayDialog) {
+                    if (state is BirthdaysShowDialog) {
                       showDialog(
                           context: context,
                           builder: (_) => BlocProvider.value(

--- a/test/birthday_widget_test.dart
+++ b/test/birthday_widget_test.dart
@@ -85,32 +85,31 @@ void main() {
                                 notificationService, storageService, birthdays),
                             child: BlocBuilder<BirthdaysBloc, BirthdaysState>(
                                 builder: (context, state) {
+                              final currentState = state;
                               return Column(children: [
-                                (state.birthdays == null ||
-                                        state.birthdays!.length == 0)
-                                    ? Spacer()
-                                    : Expanded(
+                                if (currentState is BirthdaysLoaded && currentState.birthdays.isNotEmpty)
+                                    Expanded(
                                         child: ListView.builder(
-                                          itemCount: state.birthdays != null
-                                              ? state.birthdays!.length
-                                              : 0,
+                                          itemCount: currentState.birthdays.length,
                                           itemBuilder: (BuildContext context,
                                               int index) {
                                             return BlocProvider.value(
                                                 value: BlocProvider.of<
                                                     BirthdaysBloc>(context),
                                                 child: BirthdayWidget(
-                                                    key: Key(state
-                                                        .birthdays![index]
+                                                    key: Key(currentState
+                                                        .birthdays[index]
                                                         .name),
                                                     birthdayOfPerson:
-                                                        state.birthdays![index],
+                                                        currentState.birthdays[index],
                                                     indexOfBirthday: index,
                                                     notificationService:
                                                         notificationService));
                                           },
                                         ),
-                                      ),
+                                      )
+                                else
+                                  Spacer(),
                               ]);
                             })))));
           },


### PR DESCRIPTION
Fixes #149 

This pull request refactors the birthdays feature to use a more robust and type-safe state management approach with sealed classes for `BirthdaysState`. The changes simplify state handling, improve code readability, and reduce the risk of null-related bugs. The UI and tests are updated to work with the new state model.

**State management refactor:**

* Replaces the original `BirthdaysState` class (which used nullable fields and a boolean flag) with a sealed class hierarchy: `BirthdaysLoaded` (contains the date and list of birthdays) and `BirthdaysShowDialog` (indicates the add-birthday dialog should be shown). (`lib/BirthdayBloc/BirthdaysState.dart`)
* Updates the `BirthdaysBloc` to emit the new state classes instead of the old state with nullable fields and flags. (`lib/BirthdayBloc/BirthdaysBloc.dart`) [[1]](diffhunk://#diff-ca576279c4d8fe837abce3bfb11d3fee1f9378da7d9c70f0691f7f6bb23fb08dL29-R31) [[2]](diffhunk://#diff-ca576279c4d8fe837abce3bfb11d3fee1f9378da7d9c70f0691f7f6bb23fb08dL43-R50) [[3]](diffhunk://#diff-ca576279c4d8fe837abce3bfb11d3fee1f9378da7d9c70f0691f7f6bb23fb08dL70-R76) [[4]](diffhunk://#diff-ca576279c4d8fe837abce3bfb11d3fee1f9378da7d9c70f0691f7f6bb23fb08dL98-R98)

**UI updates:**

* Refactors the birthday list UI to check for `BirthdaysLoaded` state and directly access the non-nullable `birthdays` list, removing previous null checks. Also updates dialog display logic to use the new `BirthdaysShowDialog` state. (`lib/page/birthdays_for_calendar_day_page/birthdays_for_calendar_day.dart`)

**Test updates:**

* Updates the widget tests to use the new state classes and non-nullable fields, removing null checks and aligning with the refactored state model. (`test/birthday_widget_test.dart`)