### PR TITLE
In-app update check failures are surfaced to the user as error dialogs on every launch

### DIFF
--- a/lib/service/update_service/update_service.dart
+++ b/lib/service/update_service/update_service.dart
@@ -6,5 +6,5 @@ abstract class UpdateService {
   bool isImmediateUpdatePossible();
   bool isFlexibleUpdatePossible();
   Future<void> applyImmediateUpdate(Function onSuccess, Function onFailure, BuildContext context);
-  Future<void> startFlexibleUpdate();
+  Future<void> startFlexibleUpdate(Function onSuccess, Function onFailure, BuildContext context);
 }

--- a/lib/service/update_service/update_service_impl.dart
+++ b/lib/service/update_service/update_service_impl.dart
@@ -12,7 +12,7 @@ class UpdateServiceImpl extends UpdateService {
       _appUpdateInfo = value;
       _checkForUpdateAvailability(onSuccess, onFailure, context);
     }).catchError((error) {
-      onFailure(error.toString());
+      debugPrint("Failed to check for update: $error");
     });
   }
 
@@ -61,10 +61,20 @@ class UpdateServiceImpl extends UpdateService {
   }
 
   @override
-  Future<void> startFlexibleUpdate() async {
-    AppUpdateResult appUpdateResult = await InAppUpdate.startFlexibleUpdate();
-    if (appUpdateResult == AppUpdateResult.success) {
-      InAppUpdate.completeFlexibleUpdate();
+  Future<void> startFlexibleUpdate(
+      Function onSuccess, Function onFailure, BuildContext context) async {
+    try {
+      AppUpdateResult appUpdateResult = await InAppUpdate.startFlexibleUpdate();
+      if (appUpdateResult == AppUpdateResult.success) {
+        await InAppUpdate.completeFlexibleUpdate();
+        onSuccess();
+      } else if (appUpdateResult == AppUpdateResult.userDeniedUpdate) {
+        onFailure(AppLocalizations.of(context)!.userDeniedUpdate);
+      } else if (appUpdateResult == AppUpdateResult.inAppUpdateFailed) {
+        onFailure(AppLocalizations.of(context)!.appUpdateFailed);
+      }
+    } catch (e) {
+      onFailure(e.toString());
     }
   }
 
@@ -78,7 +88,7 @@ class UpdateServiceImpl extends UpdateService {
       } else {
         bool isFlexibleUpdateAvailable = isFlexibleUpdatePossible();
         if (isFlexibleUpdateAvailable) {
-          startFlexibleUpdate();
+          startFlexibleUpdate(onSuccess, onFailure, context);
         }
       }
     }


### PR DESCRIPTION
Fixes #157 

This pull request updates the `UpdateService` interface and its implementation to improve error handling and provide better feedback during flexible app updates. The changes focus on making the flexible update process more robust and user-friendly by passing success and failure callbacks, as well as context, throughout the update workflow.

**Flexible Update Process Improvements:**

* Modified the `startFlexibleUpdate` method in both `UpdateService` and `UpdateServiceImpl` to accept `onSuccess`, `onFailure`, and `context` parameters, allowing for more granular handling of update outcomes and localization of error messages. [[1]](diffhunk://#diff-bcc458e50d568b132a87c1ca143ce1d8e866d25b29a7b3fb6a4574e98b701053L9-R9) [[2]](diffhunk://#diff-ce8ef28ea88bc2f75b5fd43a7d9ea5d10a44eae2792c025175399c98c96955b6L64-R77) [[3]](diffhunk://#diff-ce8ef28ea88bc2f75b5fd43a7d9ea5d10a44eae2792c025175399c98c96955b6L81-R91)
* Enhanced error handling in `startFlexibleUpdate` to call appropriate callbacks with localized messages when the user denies the update, the update fails, or an exception occurs.

**Error Logging:**

* Improved error logging in the update check process by printing debug information instead of directly calling the failure callback, which helps with troubleshooting without disrupting the user flow.