### PR TITLE
Swipe to change month fires setState on every drag pixel — janky and skips months

### DIFF
--- a/lib/page/main_page/main_page.dart
+++ b/lib/page/main_page/main_page.dart
@@ -55,10 +55,13 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
     });
   }
 
-  void _decideOnNextMonthToShow(DragUpdateDetails details) {
-    details.delta.dx > 0
-        ? _calculateNextMonthToShow(AxisDirection.right)
-        : _calculateNextMonthToShow(AxisDirection.left);
+  void _onHorizontalDragEnd(DragEndDetails details) {
+    if (details.primaryVelocity == null) return;
+    if (details.primaryVelocity! > 0) {
+      _calculateNextMonthToShow(AxisDirection.right);
+    } else if (details.primaryVelocity! < 0) {
+      _calculateNextMonthToShow(AxisDirection.left);
+    }
   }
 
   void _onUpdateSuccess() {
@@ -196,7 +199,7 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
               }
             },
             child: new GestureDetector(
-                onHorizontalDragUpdate: _decideOnNextMonthToShow,
+                onHorizontalDragEnd: _onHorizontalDragEnd,
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                   crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
Fixes #158 

This pull request updates the swipe-to-change-month gesture handling on the `MainPage` to improve user experience and accuracy. Instead of changing months based on the drag update direction, the logic now responds to the velocity of the drag gesture when the user lifts their finger, ensuring that only intentional swipe gestures trigger a month change.

Gesture handling improvements:

* Replaced the `_decideOnNextMonthToShow` method (triggered on `onHorizontalDragUpdate`) with `_onHorizontalDragEnd`, which uses the drag's velocity (`primaryVelocity`) to determine the swipe direction and trigger the appropriate month change. This prevents accidental month changes from small or slow drags. (`lib/page/main_page/main_page.dart`, [lib/page/main_page/main_page.dartL58-R64](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL58-R64))
* Updated the `GestureDetector` in the widget tree to use `onHorizontalDragEnd` instead of `onHorizontalDragUpdate`, aligning the UI behavior with the new gesture handling logic. (`lib/page/main_page/main_page.dart`, [lib/page/main_page/main_page.dartL199-R202](diffhunk://#diff-fcb84592c3b64b3315c0dc68836feb090c5d31c1d0faf01fee69926cd1dbd4eeL199-R202))