### PR TITLE
Contact import deduplication uses display name only — allows duplicates and blocks distinct people with same name

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -18,6 +18,7 @@ const userBirthdayDateKey = "birthdayDate";
 const userBirthdayHasNotificationKey = "hasNotification";
 const userBirthdayPhoneNumberKey = "phoneNumber";
 const userBirthdayNotificationIdKey = "notificationId";
+const userBirthdayContactIdKey = "contactId";
 
 const darkModeKey = "darkMode";
 const contactsPermissionKey = "contacts";

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -29,6 +29,7 @@ const notificationsPermissionStatusKey = "notificationsPermissionStatusKey";
 const versionToMigrateNotificationStatusFrom = "1.2.1";
 const didAlreadyMigrateNotificationStatusFlag = "migrateNotificationStatus";
 const didAlreadyMigrateNotificationIdsFlag = "migrateNotificationIds";
+const didAlreadyMigrateContactIdsFlag = "migrateContactIds";
 
 enum NotificationPermissionState {
   unknown,

--- a/lib/model/user_birthday.dart
+++ b/lib/model/user_birthday.dart
@@ -6,6 +6,7 @@ class UserBirthday {
   bool hasNotification;
   String phoneNumber;
   final int notificationId;
+  final String contactId;
 
   static int _deterministicId(String name, DateTime date) {
     final key = '$name:${date.month}:${date.day}';
@@ -24,7 +25,7 @@ class UserBirthday {
 
   UserBirthday(
       this.name, this.birthdayDate, this.hasNotification, this.phoneNumber,
-      {int? notificationId})
+      {int? notificationId, this.contactId = ""})
       : this.notificationId =
             notificationId ?? _deterministicId(name, birthdayDate);
 
@@ -37,12 +38,16 @@ class UserBirthday {
       identical(this, other) ||
       other is UserBirthday &&
           runtimeType == other.runtimeType &&
-          name == other.name &&
-          birthdayDate.month == other.birthdayDate.month &&
-          birthdayDate.day == other.birthdayDate.day;
+          (contactId.isNotEmpty && other.contactId.isNotEmpty
+              ? contactId == other.contactId
+              : (name == other.name &&
+                  birthdayDate.month == other.birthdayDate.month &&
+                  birthdayDate.day == other.birthdayDate.day));
 
   @override
-  int get hashCode => Object.hash(name, birthdayDate.month, birthdayDate.day);
+  int get hashCode => contactId.isNotEmpty
+      ? contactId.hashCode
+      : Object.hash(name, birthdayDate.month, birthdayDate.day);
 
   bool equals(UserBirthday otherBirthday) {
     return this == otherBirthday;
@@ -58,12 +63,14 @@ class UserBirthday {
     final hasNotification =
         json[userBirthdayHasNotificationKey] as bool? ?? false;
     final phoneNumber = json[userBirthdayPhoneNumberKey] as String? ?? '';
+    final contactId = json[userBirthdayContactIdKey] as String? ?? '';
 
     return UserBirthday(
       name,
       parsedDate,
       hasNotification,
       phoneNumber,
+      contactId: contactId,
       notificationId: json[userBirthdayNotificationIdKey] as int? ??
           _deterministicId(name, parsedDate),
     );
@@ -74,6 +81,7 @@ class UserBirthday {
         userBirthdayDateKey: birthdayDate.toIso8601String(),
         userBirthdayHasNotificationKey: hasNotification,
         userBirthdayPhoneNumberKey: phoneNumber,
-        userBirthdayNotificationIdKey: notificationId
+        userBirthdayNotificationIdKey: notificationId,
+        userBirthdayContactIdKey: contactId
       };
 }

--- a/lib/page/main_page/main_page.dart
+++ b/lib/page/main_page/main_page.dart
@@ -164,6 +164,20 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
     } catch (e, stackTrace) {
       debugPrint("Failed to migrate notification IDs: $e\n$stackTrace");
     }
+
+    if (!mounted) return;
+
+    try {
+      // Fetch live contacts once and pass them into the migration so
+      // the service layer does not need a BuildContext or a contacts-permission
+      // check of its own. If contacts permission has not been granted yet the
+      // fetch will return an empty list and the migration will be a no-op,
+      // retrying on the next launch.
+      final contacts = await widget.contactsService.fetchContacts(false);
+      await versionSpecificService.migrateContactIds(contacts);
+    } catch (e, stackTrace) {
+      debugPrint("Failed to migrate contact IDs: $e\n$stackTrace");
+    }
   }
 
   @override
@@ -174,7 +188,8 @@ class _MainPageState extends State<MainPage> implements NotificationCallbacks {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<ClearNotificationsBloc, ClearNotificationsState>(builder: (context, state) {
+    return BlocBuilder<ClearNotificationsBloc, ClearNotificationsState>(
+        builder: (context, state) {
       return Scaffold(
           appBar: AppBar(
             actions: [

--- a/lib/service/contacts_service/contacts_service_impl.dart
+++ b/lib/service/contacts_service/contacts_service_impl.dart
@@ -88,7 +88,8 @@ class ContactsServiceImpl extends ContactsService {
             contact.displayName,
             chosenBirthDate,
             true,
-            contact.phones.isNotEmpty ? contact.phones.first.number : "");
+            contact.phones.isNotEmpty ? contact.phones.first.number : "",
+            contactId: contact.id);
 
         await addContactToCalendar(userBirthday, localizations.notificationForBirthdayMessage(userBirthday.name));
         amountOfBirthdaysSet++;
@@ -111,12 +112,11 @@ class ContactsServiceImpl extends ContactsService {
   Future<void> addContactToCalendar(UserBirthday contact, String notificationMessage) async {
     List<UserBirthday> birthdays =
         await storageService.getBirthdaysForDate(contact.birthdayDate, false);
-    String contactName = contact.name;
 
-    UserBirthday? birthdayWithSameName =
-        birthdays.firstWhereOrNull((element) => element.name == contactName);
+    UserBirthday? alreadyExists =
+        birthdays.firstWhereOrNull((element) => element == contact);
 
-    if (birthdayWithSameName != null) {
+    if (alreadyExists != null) {
       return;
     }
 

--- a/lib/service/storage_service/shared_preferences_storage.dart
+++ b/lib/service/storage_service/shared_preferences_storage.dart
@@ -45,8 +45,7 @@ class StorageServiceSharedPreferences extends StorageService {
       return birthdays;
     }
 
-    List<UserBirthday> decodedBirthdays =
-        _decodeBirthdaysFromDate(dateTime);
+    List<UserBirthday> decodedBirthdays = _decodeBirthdaysFromDate(dateTime);
     return decodedBirthdays;
   }
 
@@ -168,6 +167,36 @@ class StorageServiceSharedPreferences extends StorageService {
   }
 
   @override
+  Future<void> updateContactIdForBirthday(
+      UserBirthday birthday, String contactId) async {
+    List<UserBirthday> birthdays =
+        await getBirthdaysForDate(birthday.birthdayDate, false);
+    final int index =
+        birthdays.indexWhere((element) => element.equals(birthday));
+    if (index == -1) return;
+    final existing = birthdays[index];
+    birthdays[index] = UserBirthday(
+      existing.name,
+      existing.birthdayDate,
+      existing.hasNotification,
+      existing.phoneNumber,
+      notificationId: existing.notificationId,
+      contactId: contactId,
+    );
+    await saveBirthdaysForDate(birthday.birthdayDate, birthdays);
+  }
+
+  @override
+  Future<void> saveDidAlreadyMigrateContactIds(bool status) async {
+    await _sharedPreferences.setBool(didAlreadyMigrateContactIdsFlag, status);
+  }
+
+  @override
+  Future<bool> getAlreadyMigratedContactIds() async {
+    return _sharedPreferences.getBool(didAlreadyMigrateContactIdsFlag) ?? false;
+  }
+
+  @override
   Future<List<UserBirthday>> getAllBirthdays() async {
     List<UserBirthday> birthdays = [];
     Set<String> dates = _sharedPreferences.getKeys();
@@ -223,7 +252,8 @@ class StorageServiceSharedPreferences extends StorageService {
   @override
   Future<void> setNotificationPermissionState(
       NotificationPermissionState state) async {
-    await _sharedPreferences.setInt(notificationsPermissionStatusKey, state.index);
+    await _sharedPreferences.setInt(
+        notificationsPermissionStatusKey, state.index);
   }
 
   @override

--- a/lib/service/storage_service/shared_preferences_storage.dart
+++ b/lib/service/storage_service/shared_preferences_storage.dart
@@ -195,7 +195,7 @@ class StorageServiceSharedPreferences extends StorageService {
     List<UserBirthday> birthdays =
         await getBirthdaysForDate(birthday.birthdayDate, false);
     UserBirthday? storedBirthday =
-        birthdays.firstWhereOrNull((element) => element.name == birthday.name);
+        birthdays.firstWhereOrNull((element) => element == birthday);
     if (storedBirthday != null) {
       storedBirthday.phoneNumber = birthday.phoneNumber;
       await saveBirthdaysForDate(storedBirthday.birthdayDate, birthdays);

--- a/lib/service/storage_service/storage_service.dart
+++ b/lib/service/storage_service/storage_service.dart
@@ -20,7 +20,8 @@ abstract class StorageService {
 
   Stream<BirthdaysStreamEvent> getBirthdaysStream();
 
-  Future<void> saveIsContactsPermissionPermanentlyDenied(bool isPermanentlyDenied);
+  Future<void> saveIsContactsPermissionPermanentlyDenied(
+      bool isPermanentlyDenied);
 
   Future<bool> getIsContactPermissionPermanentlyDenied();
 
@@ -42,6 +43,13 @@ abstract class StorageService {
   Future<void> saveDidAlreadyMigrateNotificationIds(bool status);
 
   Future<bool> getAlreadyMigrateNotificationIds();
+
+  Future<void> updateContactIdForBirthday(
+      UserBirthday birthday, String contactId);
+
+  Future<void> saveDidAlreadyMigrateContactIds(bool status);
+
+  Future<bool> getAlreadyMigratedContactIds();
 
   void dispose();
 }

--- a/lib/service/version_specific_service/VersionSpecificService.dart
+++ b/lib/service/version_specific_service/VersionSpecificService.dart
@@ -1,5 +1,7 @@
+import 'package:flutter_contacts/contact.dart';
 
 abstract class VersionSpecificService {
   Future<void> migrateNotificationStatus();
   Future<void> migrateNotificationIds(String Function(String name) messageBuilder);
+  Future<void> migrateContactIds(List<Contact> liveContacts);
 }

--- a/lib/service/version_specific_service/VersionSpecificServiceImpl.dart
+++ b/lib/service/version_specific_service/VersionSpecificServiceImpl.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:pub_semver/pub_semver.dart';
+import 'package:flutter_contacts/contact.dart';
 
 class VersionSpecificServiceImpl extends VersionSpecificService {
   VersionSpecificServiceImpl(
@@ -109,6 +110,51 @@ class VersionSpecificServiceImpl extends VersionSpecificService {
     }
   }
 
+  @override
+  Future<void> migrateContactIds(List<Contact> liveContacts) async {
+    bool didAlreadyMigrate =
+        await storageService.getAlreadyMigratedContactIds();
+    if (didAlreadyMigrate) return;
+
+    List<UserBirthday> allBirthdays = await storageService.getAllBirthdays();
+    List<UserBirthday> legacyBirthdays =
+        allBirthdays.where((b) => b.contactId.isEmpty).toList();
+
+    if (legacyBirthdays.isEmpty) {
+      await storageService.saveDidAlreadyMigrateContactIds(true);
+      return;
+    }
+
+    // Build a name -> contacts map from live contacts for fast lookup.
+    // We only migrate when exactly one live contact matches the stored name —
+    // ambiguous matches are left alone rather than guessed at.
+    final Map<String, List<Contact>> contactsByName = {};
+    for (final contact in liveContacts) {
+      contactsByName.putIfAbsent(contact.displayName, () => []).add(contact);
+    }
+
+    bool allSucceeded = true;
+    for (final birthday in legacyBirthdays) {
+      final matches = contactsByName[birthday.name];
+      if (matches == null || matches.length != 1) {
+        // No match or ambiguous — leave this entry as-is.
+        continue;
+      }
+      try {
+        await storageService.updateContactIdForBirthday(
+            birthday, matches.first.id);
+      } catch (e, stackTrace) {
+        allSucceeded = false;
+        debugPrint(
+            'migrateContactIds: failed to update ${birthday.name}: $e\n$stackTrace');
+      }
+    }
+
+    if (allSucceeded) {
+      await storageService.saveDidAlreadyMigrateContactIds(true);
+    }
+  }
+
   bool _isVersionGreaterThan(String version, String threshold) {
     Version? parsedVersion = _tryParseVersion(version);
     Version? parsedThreshold = _tryParseVersion(threshold);
@@ -146,8 +192,9 @@ class VersionSpecificServiceImpl extends VersionSpecificService {
       splitIndex = dashIndex != -1 ? dashIndex : plusIndex;
     }
 
-    String versionPart =
-        splitIndex == -1 ? versionString : versionString.substring(0, splitIndex);
+    String versionPart = splitIndex == -1
+        ? versionString
+        : versionString.substring(0, splitIndex);
     String suffix = splitIndex == -1 ? "" : versionString.substring(splitIndex);
 
     List<String> segments = versionPart.split('.');

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -12,10 +12,21 @@ class Utils {
       StorageService _storageService, List<Contact> contacts) async {
     List<UserBirthday> allStoredBirthdays =
         await _storageService.getAllBirthdays();
-    List<String> names = allStoredBirthdays.map((e) => e.name).toList();
-    List<Contact> filtered = contacts
-        .where((contact) => !names.contains(contact.displayName))
-        .toList();
+    Set<String> existingContactIds = allStoredBirthdays
+        .map((e) => e.contactId)
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    Set<String> legacyNames = allStoredBirthdays
+        .where((e) => e.contactId.isEmpty)
+        .map((e) => e.name)
+        .toSet();
+
+    List<Contact> filtered = contacts.where((contact) {
+      if (existingContactIds.contains(contact.id)) {
+        return false;
+      }
+      return !legacyNames.contains(contact.displayName);
+    }).toList();
     return filtered;
   }
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -16,18 +16,21 @@ class Utils {
         .map((e) => e.contactId)
         .where((id) => id.isNotEmpty)
         .toSet();
+
+    // Legacy entries (contactId still empty) are matched by name until the
+    // one-time migrateContactIds migration assigns them a proper id.
     Set<String> legacyNames = allStoredBirthdays
         .where((e) => e.contactId.isEmpty)
         .map((e) => e.name)
         .toSet();
 
-    List<Contact> filtered = contacts.where((contact) {
-      if (existingContactIds.contains(contact.id)) {
-        return false;
-      }
-      return !legacyNames.contains(contact.displayName);
+    return contacts.where((contact) {
+      if (existingContactIds.contains(contact.id)) return false;
+      // Once migration has run, legacyNames will be empty and this check
+      // becomes a no-op. Until then it prevents re-importing the same person.
+      if (legacyNames.contains(contact.displayName)) return false;
+      return true;
     }).toList();
-    return filtered;
   }
 
   static UserBirthday? getUserBirthdayFromPayload(String? payload) {

--- a/test/calendar_day_widget_test.dart
+++ b/test/calendar_day_widget_test.dart
@@ -15,24 +15,39 @@ import 'package:permission_handler/permission_handler.dart';
 class MockNotificationService implements NotificationService {
   @override
   Future<void> init(BuildContext context) async {}
+
   @override
-  Future<bool> isNotificationPermissionGranted(BuildContext context) async => true;
+  Future<bool> isNotificationPermissionGranted(BuildContext context) async =>
+      true;
+
   @override
-  Future<PermissionStatus> requestNotificationPermission(BuildContext context) async => PermissionStatus.granted;
+  Future<PermissionStatus> requestNotificationPermission(
+          BuildContext context) async =>
+      PermissionStatus.granted;
+
   @override
-  Future<void> scheduleNotificationForBirthday(UserBirthday userBirthday, String notificationMessage) async {}
+  Future<void> scheduleNotificationForBirthday(
+      UserBirthday userBirthday, String notificationMessage) async {}
+
   @override
   Future<void> cancelNotificationForBirthday(UserBirthday birthday) async {}
+
   @override
   Future<void> cancelAllNotifications() async {}
+
   @override
-  Future<List<PendingNotificationRequest>> getAllScheduledNotifications() async => [];
+  Future<List<PendingNotificationRequest>>
+      getAllScheduledNotifications() async => [];
+
   @override
   void dispose() {}
+
   @override
   void addListenerForSelectNotificationStream(NotificationCallbacks listener) {}
+
   @override
-  void removeListenerForSelectNotificationStream(NotificationCallbacks listener) {}
+  void removeListenerForSelectNotificationStream(
+      NotificationCallbacks listener) {}
 }
 
 class MockStorageService extends StorageService {
@@ -47,38 +62,71 @@ class MockStorageService extends StorageService {
 
   @override
   Future<void> clearAllBirthdays() async {}
+
   @override
-  Future<List<UserBirthday>> getBirthdaysForDate(DateTime dateTime, bool shouldGetBirthdaysFromSimilarDate) async => [];
+  Future<List<UserBirthday>> getBirthdaysForDate(
+          DateTime dateTime, bool shouldGetBirthdaysFromSimilarDate) async =>
+      [];
+
   @override
   Future<bool> getThemeModeSetting() async => false;
+
   @override
-  Future<void> saveBirthdaysForDate(DateTime dateTime, List<UserBirthday> birthdays) async {}
+  Future<void> saveBirthdaysForDate(
+      DateTime dateTime, List<UserBirthday> birthdays) async {}
+
   @override
   Future<void> saveThemeModeSetting(bool isDarkModeEnabled) async {}
+
   @override
-  Future<void> updateNotificationStatusForBirthday(UserBirthday userBirthday, bool updatedStatus) async {}
+  Future<void> updateNotificationStatusForBirthday(
+      UserBirthday userBirthday, bool updatedStatus) async {}
+
   @override
-  Future<void> saveIsContactsPermissionPermanentlyDenied(bool isPermanentlyDenied) async {}
+  Future<void> saveIsContactsPermissionPermanentlyDenied(
+      bool isPermanentlyDenied) async {}
+
   @override
   Future<bool> getIsContactPermissionPermanentlyDenied() async => false;
+
   @override
   Future<void> saveDidAlreadyMigrateNotificationStatus(bool status) async {}
+
   @override
   Future<bool> getAlreadyMigrateNotificationStatus() async => false;
+
   @override
   Future<void> saveDidAlreadyMigrateNotificationIds(bool status) async {}
+
   @override
   Future<bool> getAlreadyMigrateNotificationIds() async => false;
+
   @override
   Future<List<UserBirthday>> getAllBirthdays() async => [];
+
   @override
   Future<void> updatePhoneNumberForBirthday(UserBirthday birthday) async {}
+
   @override
   Future<void> updateNotificationIdForBirthday(UserBirthday birthday) async {}
+
   @override
-  Future<void> setNotificationPermissionState(NotificationPermissionState state) async {}
+  Future<void> setNotificationPermissionState(
+      NotificationPermissionState state) async {}
+
   @override
-  Future<NotificationPermissionState> getNotificationPermissionState() async => NotificationPermissionState.unknown;
+  Future<NotificationPermissionState> getNotificationPermissionState() async =>
+      NotificationPermissionState.unknown;
+
+  @override
+  Future<void> updateContactIdForBirthday(
+      UserBirthday birthday, String contactId) async {}
+
+  @override
+  Future<void> saveDidAlreadyMigrateContactIds(bool status) async {}
+
+  @override
+  Future<bool> getAlreadyMigratedContactIds() async => false;
 
   void dispose() {
     _controller.close();
@@ -86,7 +134,9 @@ class MockStorageService extends StorageService {
 }
 
 void main() {
-  testWidgets('CalendarDayWidget updates UI when birthday notification status changes', (WidgetTester tester) async {
+  testWidgets(
+      'CalendarDayWidget updates UI when birthday notification status changes',
+      (WidgetTester tester) async {
     final mockStorageService = MockStorageService();
     final mockNotificationService = MockNotificationService();
     final date = DateTime(2023, 1, 1);
@@ -121,37 +171,38 @@ void main() {
 
     // Verify it still shows the cake
     expect(find.byIcon(Icons.cake_outlined), findsOneWidget);
-    
+
     mockStorageService.dispose();
   });
 
-  testWidgets('CalendarDayWidget does not update if mounted is false', (WidgetTester tester) async {
-     final mockStorageService = MockStorageService();
-     final mockNotificationService = MockNotificationService();
-     final date = DateTime(2023, 1, 1);
+  testWidgets('CalendarDayWidget does not update if mounted is false',
+      (WidgetTester tester) async {
+    final mockStorageService = MockStorageService();
+    final mockNotificationService = MockNotificationService();
+    final date = DateTime(2023, 1, 1);
 
-     await tester.pumpWidget(
-       MaterialApp(
-         home: Provider<StorageService>.value(
-           value: mockStorageService,
-           child: CalendarDayWidget(
-             key: Key('calendar_day'),
-             date: date,
-             notificationService: mockNotificationService,
-           ),
-         ),
-       ),
-     );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Provider<StorageService>.value(
+          value: mockStorageService,
+          child: CalendarDayWidget(
+            key: Key('calendar_day'),
+            date: date,
+            notificationService: mockNotificationService,
+          ),
+        ),
+      ),
+    );
 
-     // Unmount the widget
-     await tester.pumpWidget(Container());
+    // Unmount the widget
+    await tester.pumpWidget(Container());
 
-     // Emit an event
-     mockStorageService.emit(date, [UserBirthday('Test', date, false, '')]);
-     
-     // Should not crash
-     await tester.pump();
-     
-     mockStorageService.dispose();
+    // Emit an event
+    mockStorageService.emit(date, [UserBirthday('Test', date, false, '')]);
+
+    // Should not crash
+    await tester.pump();
+
+    mockStorageService.dispose();
   });
 }

--- a/test/migrate_contact_ids_test.dart
+++ b/test/migrate_contact_ids_test.dart
@@ -10,11 +10,6 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:birthday_calendar/constants.dart';
-
-// ---------------------------------------------------------------------------
-// Minimal mock — only the methods touched by migrateContactIds matter.
-// ---------------------------------------------------------------------------
 
 class MockNotificationService implements NotificationService {
   @override

--- a/test/migrate_contact_ids_test.dart
+++ b/test/migrate_contact_ids_test.dart
@@ -1,0 +1,268 @@
+import 'package:birthday_calendar/model/user_birthday.dart';
+import 'package:birthday_calendar/service/notification_service/notification_service.dart';
+import 'package:birthday_calendar/service/storage_service/shared_preferences_storage.dart';
+import 'package:birthday_calendar/service/storage_service/storage_service.dart';
+import 'package:birthday_calendar/service/version_specific_service/VersionSpecificServiceImpl.dart';
+import 'package:birthday_calendar/service/notification_service/notificationCallbacks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_contacts/contact.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:birthday_calendar/constants.dart';
+
+// ---------------------------------------------------------------------------
+// Minimal mock — only the methods touched by migrateContactIds matter.
+// ---------------------------------------------------------------------------
+
+class MockNotificationService implements NotificationService {
+  @override
+  Future<void> init(BuildContext context) async {}
+
+  @override
+  Future<bool> isNotificationPermissionGranted(BuildContext context) async =>
+      true;
+
+  @override
+  Future<PermissionStatus> requestNotificationPermission(
+          BuildContext context) async =>
+      PermissionStatus.granted;
+
+  @override
+  Future<void> scheduleNotificationForBirthday(
+      UserBirthday b, String msg) async {}
+
+  @override
+  Future<void> cancelNotificationForBirthday(UserBirthday b) async {}
+
+  @override
+  Future<void> cancelAllNotifications() async {}
+
+  @override
+  Future<List<PendingNotificationRequest>>
+      getAllScheduledNotifications() async => [];
+
+  @override
+  void dispose() {}
+
+  @override
+  void addListenerForSelectNotificationStream(NotificationCallbacks l) {}
+
+  @override
+  void removeListenerForSelectNotificationStream(NotificationCallbacks l) {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a [Contact] stub with the two fields [migrateContactIds] uses.
+Contact makeContact(String id, String displayName) =>
+    Contact(id: id, displayName: displayName);
+
+/// Convenience: read back a stored birthday by name from storage.
+Future<UserBirthday?> fetchByName(
+    StorageService storage, DateTime date, String name) async {
+  final list = await storage.getBirthdaysForDate(date, false);
+  try {
+    return list.firstWhere((b) => b.name == name);
+  } catch (_) {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late StorageService storageService;
+  late VersionSpecificServiceImpl versionService;
+  final date = DateTime(1990, 6, 15);
+
+  setUp(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    storageService = StorageServiceSharedPreferences(prefs);
+    versionService = VersionSpecificServiceImpl(
+      storageService: storageService,
+      notificationService: MockNotificationService(),
+    );
+  });
+
+  group('migrateContactIds — guard conditions', () {
+    test('does nothing when migration flag is already set', () async {
+      // Store a legacy birthday and pre-set the flag.
+      final legacy = UserBirthday('Alice', date, false, '');
+      await storageService.saveBirthdaysForDate(date, [legacy]);
+      await storageService.saveDidAlreadyMigrateContactIds(true);
+
+      final contact = makeContact('c-1', 'Alice');
+      await versionService.migrateContactIds([contact]);
+
+      // The entry should NOT have been updated because we skipped early.
+      final stored = await fetchByName(storageService, date, 'Alice');
+      expect(stored?.contactId, equals(''));
+    });
+
+    test('sets flag immediately when there are no legacy entries', () async {
+      // Store a birthday that already has a contactId.
+      final modern = UserBirthday('Alice', date, false, '', contactId: 'c-1');
+      await storageService.saveBirthdaysForDate(date, [modern]);
+
+      await versionService.migrateContactIds([]);
+
+      expect(await storageService.getAlreadyMigratedContactIds(), isTrue);
+    });
+
+    test('sets flag immediately when storage is completely empty', () async {
+      await versionService.migrateContactIds([]);
+      expect(await storageService.getAlreadyMigratedContactIds(), isTrue);
+    });
+  });
+
+  group('migrateContactIds — matching logic', () {
+    test('updates contactId when exactly one live contact matches by name',
+        () async {
+      final legacy = UserBirthday('Alice', date, false, '');
+      await storageService.saveBirthdaysForDate(date, [legacy]);
+
+      final contact = makeContact('c-alice', 'Alice');
+      await versionService.migrateContactIds([contact]);
+
+      final stored = await fetchByName(storageService, date, 'Alice');
+      expect(stored?.contactId, equals('c-alice'));
+    });
+
+    test('sets migration flag after successful update', () async {
+      final legacy = UserBirthday('Alice', date, false, '');
+      await storageService.saveBirthdaysForDate(date, [legacy]);
+
+      await versionService.migrateContactIds([makeContact('c-alice', 'Alice')]);
+
+      expect(await storageService.getAlreadyMigratedContactIds(), isTrue);
+    });
+
+    test('skips entry when no live contact matches the name', () async {
+      final legacy = UserBirthday('Alice', date, false, '');
+      await storageService.saveBirthdaysForDate(date, [legacy]);
+
+      // No contact named Alice in the live list.
+      await versionService.migrateContactIds([makeContact('c-bob', 'Bob')]);
+
+      final stored = await fetchByName(storageService, date, 'Alice');
+      expect(stored?.contactId, equals(''));
+      // Flag is still set because the only failure was a skip, not an error.
+      expect(await storageService.getAlreadyMigratedContactIds(), isTrue);
+    });
+
+    test(
+        'skips entry when multiple live contacts share the same name (ambiguous)',
+        () async {
+      final legacy = UserBirthday('Alice', date, false, '');
+      await storageService.saveBirthdaysForDate(date, [legacy]);
+
+      final contacts = [
+        makeContact('c-1', 'Alice'),
+        makeContact('c-2', 'Alice'),
+      ];
+      await versionService.migrateContactIds(contacts);
+
+      final stored = await fetchByName(storageService, date, 'Alice');
+      expect(stored?.contactId, equals(''));
+      // Ambiguous skips do not prevent the flag from being set.
+      expect(await storageService.getAlreadyMigratedContactIds(), isTrue);
+    });
+
+    test(
+        'migrates only unambiguous entries and leaves ambiguous ones untouched',
+        () async {
+      final alice = UserBirthday('Alice', date, false, '');
+      final bob = UserBirthday('Bob', date, false, '');
+      await storageService.saveBirthdaysForDate(date, [alice, bob]);
+
+      // Two Alices (ambiguous), one Bob (unambiguous).
+      final contacts = [
+        makeContact('c-alice-1', 'Alice'),
+        makeContact('c-alice-2', 'Alice'),
+        makeContact('c-bob', 'Bob'),
+      ];
+      await versionService.migrateContactIds(contacts);
+
+      final storedAlice = await fetchByName(storageService, date, 'Alice');
+      final storedBob = await fetchByName(storageService, date, 'Bob');
+      expect(storedAlice?.contactId, equals(''));
+      expect(storedBob?.contactId, equals('c-bob'));
+      expect(await storageService.getAlreadyMigratedContactIds(), isTrue);
+    });
+
+    test('does not touch entries that already have a contactId', () async {
+      final modern =
+          UserBirthday('Alice', date, false, '', contactId: 'existing-id');
+      await storageService.saveBirthdaysForDate(date, [modern]);
+
+      // Even if a contact matches by name, already-migrated entries are not re-processed
+      // because they are filtered out of legacyBirthdays before the loop.
+      await versionService.migrateContactIds([makeContact('new-id', 'Alice')]);
+
+      final stored = await fetchByName(storageService, date, 'Alice');
+      expect(stored?.contactId, equals('existing-id'));
+    });
+
+    test('migrates multiple legacy entries across different dates', () async {
+      final date2 = DateTime(1985, 3, 22);
+      final alice = UserBirthday('Alice', date, false, '');
+      final bob = UserBirthday('Bob', date2, false, '');
+      await storageService.saveBirthdaysForDate(date, [alice]);
+      await storageService.saveBirthdaysForDate(date2, [bob]);
+
+      final contacts = [
+        makeContact('c-alice', 'Alice'),
+        makeContact('c-bob', 'Bob'),
+      ];
+      await versionService.migrateContactIds(contacts);
+
+      final storedAlice = await fetchByName(storageService, date, 'Alice');
+      final storedBob = await fetchByName(storageService, date2, 'Bob');
+      expect(storedAlice?.contactId, equals('c-alice'));
+      expect(storedBob?.contactId, equals('c-bob'));
+      expect(await storageService.getAlreadyMigratedContactIds(), isTrue);
+    });
+
+    test('preserves all other fields on the updated entry', () async {
+      final legacy = UserBirthday(
+        'Alice',
+        date,
+        true,
+        '+1 555 0100',
+        notificationId: 42,
+      );
+      await storageService.saveBirthdaysForDate(date, [legacy]);
+
+      await versionService.migrateContactIds([makeContact('c-alice', 'Alice')]);
+
+      final stored = await fetchByName(storageService, date, 'Alice');
+      expect(stored?.hasNotification, isTrue);
+      expect(stored?.phoneNumber, equals('+1 555 0100'));
+      expect(stored?.notificationId, equals(42));
+      expect(stored?.contactId, equals('c-alice'));
+    });
+
+    test(
+        'is idempotent — running twice does not overwrite already-set contactIds',
+        () async {
+      final legacy = UserBirthday('Alice', date, false, '');
+      await storageService.saveBirthdaysForDate(date, [legacy]);
+
+      final contacts = [makeContact('c-alice', 'Alice')];
+      await versionService.migrateContactIds(contacts);
+      // Second run should exit at the guard (flag already set).
+      await versionService.migrateContactIds(contacts);
+
+      final stored = await fetchByName(storageService, date, 'Alice');
+      expect(stored?.contactId, equals('c-alice'));
+    });
+  });
+}

--- a/test/notification_id_test.dart
+++ b/test/notification_id_test.dart
@@ -51,4 +51,33 @@ void main() {
       expect(b.notificationId, equals(42));
     });
   });
+
+  group('UserBirthday equality and contactId', () {
+    test('equality uses contactId when both have it', () {
+      final date = DateTime(1990, 6, 15);
+      final a = UserBirthday('Alice', date, false, '', contactId: '1');
+      final b = UserBirthday('Alice renamed', date, false, '', contactId: '1');
+      expect(a, equals(b));
+    });
+
+    test('equality distinguishes same names with different contactIds', () {
+      final date = DateTime(1990, 6, 15);
+      final a = UserBirthday('Alice', date, false, '', contactId: '1');
+      final b = UserBirthday('Alice', date, false, '', contactId: '2');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('equality falls back to name and date when contactId is missing', () {
+      final date = DateTime(1990, 6, 15);
+      final a = UserBirthday('Alice', date, false, '', contactId: '');
+      final b = UserBirthday('Alice', date, false, '', contactId: '1');
+      expect(a, equals(b));
+    });
+
+    test('fromJson preserves contactId', () {
+      final original = UserBirthday('Alice', DateTime(1990, 6, 15), false, '', contactId: 'abc');
+      final decoded = UserBirthday.fromJson(original.toJson());
+      expect(decoded.contactId, equals('abc'));
+    });
+  });
 }

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -6,7 +6,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:birthday_calendar/service/storage_service/storage_service.dart';
 
 void main() {
-
   late StorageService _storageService;
 
   setUp(() async {
@@ -19,44 +18,48 @@ void main() {
 
   test("SharedPreferences get empty birthday array for date", () async {
     final DateTime dateTime = DateTime(2021, 12, 5);
-    final birthdays = await _storageService.getBirthdaysForDate(dateTime, false);
+    final birthdays =
+        await _storageService.getBirthdaysForDate(dateTime, false);
     expect(birthdays.length, 0);
   });
 
   test("SharedPreferences set birthday for date", () async {
     final DateTime dateTime = DateTime(2021, 12, 5);
-    final String phoneNumber =  '+234 500 500 5005';
-    final UserBirthday userBirthday = new UserBirthday("Someone", DateTime.now(), false, phoneNumber);
+    final String phoneNumber = '+234 500 500 5005';
+    final UserBirthday userBirthday =
+        new UserBirthday("Someone", DateTime.now(), false, phoneNumber);
     List<UserBirthday> birthdays = [];
     birthdays.add(userBirthday);
     await _storageService.saveBirthdaysForDate(dateTime, birthdays);
 
-    final storedBirthdays = await _storageService.getBirthdaysForDate(dateTime, false);
+    final storedBirthdays =
+        await _storageService.getBirthdaysForDate(dateTime, false);
     expect(storedBirthdays.length, 1);
     expect(storedBirthdays[0].name, userBirthday.name);
     expect(storedBirthdays[0].birthdayDate, userBirthday.birthdayDate);
     expect(storedBirthdays[0].hasNotification, userBirthday.hasNotification);
-
   });
 
   test("SharedPreferences clear all birthday for date", () async {
     final DateTime dateTime = DateTime(2021, 12, 5);
-    final String phoneNumber =  '+234 500 500 5005';
+    final String phoneNumber = '+234 500 500 5005';
 
-    final UserBirthday userBirthday = new UserBirthday("Someone", DateTime.now(), false, phoneNumber);
+    final UserBirthday userBirthday =
+        new UserBirthday("Someone", DateTime.now(), false, phoneNumber);
     List<UserBirthday> birthdays = [];
     birthdays.add(userBirthday);
     await _storageService.saveBirthdaysForDate(dateTime, birthdays);
 
-    List<UserBirthday> storedBirthdays = await _storageService.getBirthdaysForDate(dateTime, false);
+    List<UserBirthday> storedBirthdays =
+        await _storageService.getBirthdaysForDate(dateTime, false);
     expect(storedBirthdays.length, 1);
 
     await _storageService.clearAllBirthdays();
 
-    storedBirthdays = await _storageService.getBirthdaysForDate(dateTime, false);
+    storedBirthdays =
+        await _storageService.getBirthdaysForDate(dateTime, false);
 
     expect(storedBirthdays.length, 0);
-
   });
 
   test("SharedPreferences set ThemeMode to dark mode", () async {
@@ -65,9 +68,102 @@ void main() {
     expect(isDarkModeEnabled, true);
   });
 
-  test("SharedPreferences default contact permission status is not permanently denied", () async {
-    bool isContactsPermissionStatusPermanentlyDenied = await _storageService.getIsContactPermissionPermanentlyDenied();
+  test(
+      "SharedPreferences default contact permission status is not permanently denied",
+      () async {
+    bool isContactsPermissionStatusPermanentlyDenied =
+        await _storageService.getIsContactPermissionPermanentlyDenied();
     expect(isContactsPermissionStatusPermanentlyDenied, false);
   });
 
+  test(
+      "SharedPreferences updateContactIdForBirthday persists the new contactId",
+      () async {
+    final DateTime dateTime = DateTime(2021, 6, 15);
+    final UserBirthday original = UserBirthday("Alice", dateTime, false, "");
+    await _storageService.saveBirthdaysForDate(dateTime, [original]);
+
+    await _storageService.updateContactIdForBirthday(original, "contact-123");
+
+    final stored = await _storageService.getBirthdaysForDate(dateTime, false);
+    expect(stored.length, 1);
+    expect(stored[0].contactId, equals("contact-123"));
+  });
+
+  test(
+      "SharedPreferences updateContactIdForBirthday preserves all other fields",
+      () async {
+    final DateTime dateTime = DateTime(2021, 6, 15);
+    final UserBirthday original = UserBirthday(
+      "Alice",
+      dateTime,
+      true,
+      "+1 555 0100",
+      notificationId: 42,
+    );
+    await _storageService.saveBirthdaysForDate(dateTime, [original]);
+
+    await _storageService.updateContactIdForBirthday(original, "contact-123");
+
+    final stored = await _storageService.getBirthdaysForDate(dateTime, false);
+    expect(stored[0].name, equals("Alice"));
+    expect(stored[0].hasNotification, isTrue);
+    expect(stored[0].phoneNumber, equals("+1 555 0100"));
+    expect(stored[0].notificationId, equals(42));
+    expect(stored[0].contactId, equals("contact-123"));
+  });
+
+  test(
+      "SharedPreferences updateContactIdForBirthday only updates the matching entry",
+      () async {
+    final DateTime dateTime = DateTime(2021, 6, 15);
+    final UserBirthday alice = UserBirthday("Alice", dateTime, false, "");
+    final UserBirthday bob = UserBirthday("Bob", dateTime, false, "");
+    await _storageService.saveBirthdaysForDate(dateTime, [alice, bob]);
+
+    await _storageService.updateContactIdForBirthday(alice, "contact-alice");
+
+    final stored = await _storageService.getBirthdaysForDate(dateTime, false);
+    final storedAlice = stored.firstWhere((b) => b.name == "Alice");
+    final storedBob = stored.firstWhere((b) => b.name == "Bob");
+    expect(storedAlice.contactId, equals("contact-alice"));
+    expect(storedBob.contactId, equals(""));
+  });
+
+  test(
+      "SharedPreferences updateContactIdForBirthday is a no-op when entry not found",
+      () async {
+    final DateTime dateTime = DateTime(2021, 6, 15);
+    final UserBirthday alice = UserBirthday("Alice", dateTime, false, "");
+    final UserBirthday ghost = UserBirthday("Ghost", dateTime, false, "");
+    await _storageService.saveBirthdaysForDate(dateTime, [alice]);
+
+    // Should not throw
+    await _storageService.updateContactIdForBirthday(ghost, "contact-ghost");
+
+    final stored = await _storageService.getBirthdaysForDate(dateTime, false);
+    expect(stored.length, 1);
+    expect(stored[0].name, equals("Alice"));
+  });
+
+  test("SharedPreferences migrateContactIds flag defaults to false", () async {
+    final migrated = await _storageService.getAlreadyMigratedContactIds();
+    expect(migrated, isFalse);
+  });
+
+  test("SharedPreferences saveDidAlreadyMigrateContactIds persists true",
+      () async {
+    await _storageService.saveDidAlreadyMigrateContactIds(true);
+    final migrated = await _storageService.getAlreadyMigratedContactIds();
+    expect(migrated, isTrue);
+  });
+
+  test(
+      "SharedPreferences saveDidAlreadyMigrateContactIds can be reset to false",
+      () async {
+    await _storageService.saveDidAlreadyMigrateContactIds(true);
+    await _storageService.saveDidAlreadyMigrateContactIds(false);
+    final migrated = await _storageService.getAlreadyMigratedContactIds();
+    expect(migrated, isFalse);
+  });
 }

--- a/test/user_birthday_test.dart
+++ b/test/user_birthday_test.dart
@@ -48,7 +48,8 @@ void main() {
   group('UserBirthday equality and hashCode', () {
     test('same name, month, day but different year should be equal', () {
       final birthday1 = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
-      final birthday2 = UserBirthday('Alice', DateTime(2000, 6, 15), true, '123');
+      final birthday2 =
+          UserBirthday('Alice', DateTime(2000, 6, 15), true, '123');
 
       expect(birthday1 == birthday2, isTrue);
       expect(birthday1.hashCode, equals(birthday2.hashCode));
@@ -83,6 +84,36 @@ void main() {
     test('comparison with different type should be false', () {
       final birthday = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
       expect(birthday == 'Alice', isFalse);
+    });
+
+    test('matching contactIds are equal regardless of name or date', () {
+      final birthday1 = UserBirthday('Alice', DateTime(1990, 6, 15), false, '',
+          contactId: 'c-1');
+      final birthday2 = UserBirthday('Bob', DateTime(2000, 3, 22), true, '555',
+          contactId: 'c-1');
+
+      expect(birthday1 == birthday2, isTrue);
+      expect(birthday1.hashCode, equals(birthday2.hashCode));
+    });
+
+    test('different contactIds are not equal even with same name and date', () {
+      final birthday1 = UserBirthday('Alice', DateTime(1990, 6, 15), false, '',
+          contactId: 'c-1');
+      final birthday2 = UserBirthday('Alice', DateTime(1990, 6, 15), false, '',
+          contactId: 'c-2');
+
+      expect(birthday1 == birthday2, isFalse);
+    });
+
+    test('one with contactId and one without fall back to name+date comparison',
+        () {
+      // Mixed case: one entry already migrated, the other legacy.
+      // Should still match on name+date so existing find-by-identity logic works.
+      final withId = UserBirthday('Alice', DateTime(1990, 6, 15), false, '',
+          contactId: 'c-1');
+      final withoutId = UserBirthday('Alice', DateTime(1990, 6, 15), false, '');
+
+      expect(withId == withoutId, isTrue);
     });
   });
 }


### PR DESCRIPTION
Fixes #159 

This pull request updates the handling of user birthdays to support matching contacts using a unique `contactId` instead of just names and dates. This makes the app more robust against contact renames and avoids duplicate entries for the same person. The changes affect the model, storage, and filtering logic, and add tests for the new behavior.

### Contact identification and equality

* Added a new `contactId` field to the `UserBirthday` model, and updated the constructor, serialization (`toJson`/`fromJson`), and equality/hashCode logic to use `contactId` when present, falling back to name and date otherwise. [[1]](diffhunk://#diff-ffc9dd2fb7ad6b6c611ec7eb13703dfa34a6cb0e211fd4177cdba91145f2d1f9R9) [[2]](diffhunk://#diff-ffc9dd2fb7ad6b6c611ec7eb13703dfa34a6cb0e211fd4177cdba91145f2d1f9L27-R28) [[3]](diffhunk://#diff-ffc9dd2fb7ad6b6c611ec7eb13703dfa34a6cb0e211fd4177cdba91145f2d1f9L40-R50) [[4]](diffhunk://#diff-ffc9dd2fb7ad6b6c611ec7eb13703dfa34a6cb0e211fd4177cdba91145f2d1f9R66-R73) [[5]](diffhunk://#diff-ffc9dd2fb7ad6b6c611ec7eb13703dfa34a6cb0e211fd4177cdba91145f2d1f9L77-R85)
* Updated the constant keys in `constants.dart` to include `userBirthdayContactIdKey`.

### Service and storage updates

* Updated `ContactsServiceImpl` and `StorageServiceSharedPreferences` to use the new equality logic for detecting duplicates, preventing multiple entries for the same contact, even if the name changes. [[1]](diffhunk://#diff-99859e899d653cd6ff21353aa2ce62faa076b087cd4be13866e114069fb39de0L91-R92) [[2]](diffhunk://#diff-99859e899d653cd6ff21353aa2ce62faa076b087cd4be13866e114069fb39de0L114-R119) [[3]](diffhunk://#diff-688baf8b97d284c810bf85ca0ce342cc1483ef6f60277acd5698c7530c35f0b0L198-R198)

### Contact filtering improvements

* Improved the logic for filtering contacts in `utils.dart` to exclude contacts already stored by `contactId`, and to handle legacy entries by name if no `contactId` is set.

### Testing

* Added comprehensive tests to verify the new equality logic, including cases with and without `contactId`, and ensuring JSON serialization preserves the field.